### PR TITLE
Fix bug with VarAccess recognizing identifiers in Javadoc comments

### DIFF
--- a/src/main/java/org/openrewrite/analysis/trait/expr/Expr.java
+++ b/src/main/java/org/openrewrite/analysis/trait/expr/Expr.java
@@ -23,6 +23,7 @@ import org.openrewrite.analysis.trait.TraitFactory;
 import org.openrewrite.analysis.trait.util.TraitErrors;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Javadoc;
 
 import java.util.UUID;
 
@@ -62,7 +63,7 @@ class ExprFallback extends Top.Base implements Expr {
     }
 
     static Validation<TraitErrors, ExprFallback> viewOf(Cursor cursor) {
-        if (cursor.getValue() instanceof J.Identifier) {
+        if (cursor.getValue() instanceof J.Identifier && cursor.firstEnclosing(Javadoc.class) == null) {
             return TraitErrors.invalidTraitCreation(ExprFallback.class, "Identifiers are only Expr when they are VarAccess");
         }
         if (cursor.getValue() instanceof J.FieldAccess && cursor.firstEnclosing(J.Import.class) != null) {

--- a/src/main/java/org/openrewrite/analysis/trait/expr/VarAccess.java
+++ b/src/main/java/org/openrewrite/analysis/trait/expr/VarAccess.java
@@ -32,6 +32,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Javadoc;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -236,6 +237,9 @@ class VarAccessBase extends Top.Base implements VarAccess {
         if (checkType(parent, J.MethodInvocation.class, parentMethodInvocation -> parentMethodInvocation.getName() == ident)) {
             assert ident.getFieldType() == null;
             return TraitErrors.invalidTraitCreationError("J.Identifier within a method invocation name is not a variable access");
+        }
+        if (cursor.firstEnclosing(Javadoc.class) != null) {
+            return TraitErrors.invalidTraitCreationError("J.Identifier as an argument in a method call directly only appears in Javadoc comments");
         }
         if (checkType(parent, J.MethodDeclaration.class, parentMethodDeclaration -> parentMethodDeclaration.getName() == ident)) {
             assert ident.getFieldType() == null;

--- a/src/test/java/org/openrewrite/analysis/trait/variable/JavadocTest.java
+++ b/src/test/java/org/openrewrite/analysis/trait/variable/JavadocTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.trait.variable;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.analysis.trait.expr.VarAccess;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class JavadocTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+            @Override
+            public J preVisit(J tree, ExecutionContext executionContext) {
+                return VarAccess.viewOf(getCursor())
+                  .map(var -> {
+                      assertNotNull(var.getVariable(), "VarAccess.getVariable() is null");
+                      return SearchResult.found(tree);
+                  })
+                  .orSuccess(tree);
+            }
+        }));
+    }
+
+    @Test
+    void javadocWithSee() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  /**
+                   * @see #bar(String str)
+                   */
+                  void foo() {
+                      // no-op
+                  }
+              
+                  void bar(String str)
+                  {
+                      // no-op
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void differentJavadocWithSee() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  /**
+                   * @see #bar(String)
+                   */
+                  void foo() {
+                      // no-op
+                  }
+              
+                  void bar(String str)
+                  {
+                      // no-op
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void javadocStaticField() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  /**
+                   * @value #HELLO
+                   */
+                  static final String HELLO = "hello";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void javadocWithCode() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  /**
+                   * This method takes a {@code String} and
+                   * a {@code int} as parameters
+                   */
+                  void foobar(String s, int i) {
+                      // no-op
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void javadocWithCodeHtml() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  /**
+                   * This method takes a <code>String</code> and
+                   * a <code>int</code> as parameters
+                   */
+                  void foobar(String s, int i) {
+                      // no-op
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void javadocWithThrows() {
+        rewriteRun(
+          java(
+            """
+              import java.io.IOException;
+              
+              class Test {
+                  /**
+                   * @throws IOException This method throws an exception
+                   */
+                  void foo() throws IOException {
+                      throw new IOException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void javadocWithLink() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  /**
+                   * {@link #foo(String, float) foo}
+                   */
+                  void foo(String s, float f) {
+                      // no-op
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
- Fixed bug with `VarAccess` attempting to create an instance when an `Identifier` is present in a Javadoc comment