### PR TITLE
Don't stop iteration on constructor calls, only anonymous subclasses

### DIFF
--- a/src/main/java/org/openrewrite/analysis/InvocationMatcher.java
+++ b/src/main/java/org/openrewrite/analysis/InvocationMatcher.java
@@ -164,7 +164,7 @@ public interface InvocationMatcher {
         }
 
         private static boolean asExpression(Cursor cursor, Predicate<Expression> expressionPredicate) {
-            return cursor.getValue() instanceof Expression && expressionPredicate.test((Expression) cursor.getValue());
+            return cursor.getValue() instanceof Expression && expressionPredicate.test(cursor.getValue());
         }
     }
 }

--- a/src/main/java/org/openrewrite/analysis/trait/variable/Field.java
+++ b/src/main/java/org/openrewrite/analysis/trait/variable/Field.java
@@ -55,7 +55,8 @@ public interface Field extends Member, Variable {
                 Cursor maybeVariableDecl = cursor.getParentTreeCursor();
                 Cursor maybeBlock = maybeVariableDecl.getParentTreeCursor();
                 Cursor maybeClassDecl = maybeBlock.getParentTreeCursor();
-                if (maybeClassDecl.getValue() instanceof J.ClassDeclaration || maybeClassDecl.getValue() instanceof J.NewClass) {
+                if (maybeClassDecl.getValue() instanceof J.ClassDeclaration ||
+                    maybeClassDecl.getValue() instanceof J.NewClass && ((J.NewClass) maybeClassDecl.getValue()).getBody() != null) {
                     return Validation.success(new FieldFromCursor(cursor, cursor.getValue(), maybeVariableDecl.getValue(), maybeBlock));
                 }
                 return TraitErrors.invalidTraitCreationError("Field must be declared in a class, interface, or anonymous class");

--- a/src/main/java/org/openrewrite/analysis/trait/variable/LocalVariableDecl.java
+++ b/src/main/java/org/openrewrite/analysis/trait/variable/LocalVariableDecl.java
@@ -105,7 +105,7 @@ class LocalVariableDeclBase extends Top.Base implements LocalVariableDecl {
         while (path.hasNext()) {
             Cursor c = path.next();
             Tree t = c.getValue();
-            if (t instanceof J.ClassDeclaration || t instanceof J.NewClass) {
+            if (t instanceof J.ClassDeclaration || t instanceof J.NewClass && previous != null && ((J.NewClass) t).getBody() == previous.getValue()) {
                 break;
             }
             if (t instanceof J.Block && J.Block.isStaticOrInitBlock(c)) {
@@ -120,6 +120,12 @@ class LocalVariableDeclBase extends Top.Base implements LocalVariableDecl {
                 J.MethodDeclaration m = (J.MethodDeclaration) t;
                 assert previous != null : "previous should not be null";
                 if (m.getParameters().contains(previous.<Statement>getValue())) {
+                    break;
+                }
+            } else if (t instanceof J.Lambda) {
+                J.Lambda l = (J.Lambda) t;
+                assert previous != null : "previous should not be null";
+                if (l.getParameters().getParameters().contains(previous.<Statement>getValue())) {
                     break;
                 }
             }

--- a/src/test/java/org/openrewrite/analysis/trait/variable/LambdaTest.java
+++ b/src/test/java/org/openrewrite/analysis/trait/variable/LambdaTest.java
@@ -46,7 +46,6 @@ public class LambdaTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("https://github.com/openrewrite/rewrite-analysis/issues/31")
     void lambdaException() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
The lambda support is basically already there. What was missing for the existing `LambdaTest` test case was that the iteration in `LocalVariableDecl#findNearestParentCallable()` stopped on any constructor invocation, rather than only when iterating out of the body of an anonymous subclasses.

Fixes: #31
