### PR TITLE
Support Locating AST elements by Line/Column

### DIFF
--- a/src/main/java/org/openrewrite/analysis/util/CoordinateLocator.java
+++ b/src/main/java/org/openrewrite/analysis/util/CoordinateLocator.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.util;
+
+import fj.data.Option;
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.Cursor;
+import org.openrewrite.Incubating;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaPrinter;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Space;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Incubating(since = "2.1.6")
+public class CoordinateLocator {
+
+    /**
+     * Find the first element in the AST at the given line and column.
+     * <p>
+     * <strong>NOTE:</strong> line and column numbers are 1-based, which matches the behavior of most editors.
+     * </p>
+     *
+     * @param sourceFile The source file to search.
+     * @param line       The line number to search. 1-based.
+     * @param column     The column number to search. 1-based.
+     * @return The first element found at the given line and column, or {@link Option#none()} if no element was found.
+     */
+    public static Option<J> findCoordinate(JavaSourceFile sourceFile, int line, int column) {
+        if (line < 1 || column < 1) {
+            throw new IllegalArgumentException("Line and column numbers must be 1-based");
+        }
+        AtomicReference<J> found = new AtomicReference<>();
+        CoordinateLocatorVisitor<Integer> locatorVisitor = new CoordinateLocatorVisitor<>(line, column, found);
+        locatorVisitor.visit(
+                sourceFile,
+                locatorVisitor.new CoordinateLocatorPrinter(0), new Cursor(null, "root")
+        );
+        return Option.fromNull(found.get());
+    }
+
+
+    @RequiredArgsConstructor
+    private static class CoordinateLocatorVisitor<P> extends JavaPrinter<P> {
+        private final int line;
+        private final int column;
+        private final AtomicReference<J> found;
+        private int foundLineNumber = 1;
+        private int foundColumnNumber = 1;
+        private boolean foundLine = false;
+        private boolean foundColumn = false;
+
+        @Override
+        public @Nullable J preVisit(J tree, PrintOutputCapture<P> printOutputCapture) {
+            if (foundLine && foundColumn && found.get() == null) {
+                found.set(tree);
+                stopAfterPreVisit();
+                return tree;
+            }
+            return tree;
+        }
+
+        class CoordinateLocatorPrinter extends PrintOutputCapture<P> {
+
+            public CoordinateLocatorPrinter(P p) {
+                super(p);
+            }
+
+            @Override
+            public PrintOutputCapture<P> append(@Nullable String text) {
+                if (found.get() != null) {
+                    // Optimization to avoid printing the rest of the file once we've found the element
+                    return this;
+                }
+                if (text == null) {
+                    return this;
+                }
+                for (int i = 0; i < text.length(); i++) {
+                    append(text.charAt(i));
+                }
+                return this;
+            }
+
+            @Override
+            public PrintOutputCapture<P> append(char c) {
+                if (found.get() != null) {
+                    // Optimization to avoid printing the rest of the file once we've found the element
+                    return this;
+                }
+                if (isNewLine(c)) {
+                    if (foundLine && !foundColumn) {
+                        throw new IllegalStateException("Found line " + line + " but did not find column " + column);
+                    }
+                    foundLineNumber++;
+                }
+                if (foundLineNumber == line) {
+                    foundLine = true;
+                }
+                if (foundLine && !isNewLine(c)) {
+                    foundColumnNumber++;
+                }
+                if (foundLine && foundColumnNumber == column) {
+                    foundColumn = true;
+                }
+                // Actually appending isn't necessary
+                return this;
+            }
+        }
+    }
+
+    /**
+     * Find all elements in the AST at the given line.
+     * <p>
+     * <strong>NOTE:</strong> line number is 1-based, which matches the behavior of most editors.
+     * </p>
+     *
+     * @param sourceFile The source file to search.
+     * @param line       The line number to search. 1-based.
+     * @return The elements found at the given line, or an empty collection if no elements were found.
+     */
+    public static Collection<J> findLine(JavaSourceFile sourceFile, int line) {
+        if (line < 1) {
+            throw new IllegalArgumentException("Line numbers must be 1-based");
+        }
+        Set<J> found = Collections.newSetFromMap(new IdentityHashMap<>());
+        LineLocator<Integer> locatorVisitor = new LineLocator<>(line, found);
+        locatorVisitor.visit(
+                sourceFile,
+                locatorVisitor.new LineLocatorPrinter(0), new Cursor(null, "root")
+        );
+        return Collections.unmodifiableSet(found);
+    }
+
+    @RequiredArgsConstructor
+    private static class LineLocator<P> extends JavaPrinter<P> {
+        private final int line;
+        private final Set<J> found;
+        private int foundLineNumber = 1;
+
+        private boolean foundLine() {
+            return foundLineNumber == line;
+        }
+
+        @Override
+        public @Nullable J preVisit(J tree, PrintOutputCapture<P> pPrintOutputCapture) {
+            if (tree.getPrefix().getWhitespace().chars().anyMatch(CoordinateLocator::isNewLine)) {
+                // If the element has a newline prefix, then it's on a new line
+                return tree;
+            }
+            if (tree.getPrefix().getComments().stream().anyMatch(Comment::isMultiline)) {
+                // If the element has a multiline comment prefix, then it's on a new line
+                return tree;
+            }
+            if (foundLine()) {
+                found.add(tree);
+            }
+            if (foundLineNumber > line) {
+                // Optimization to avoid visiting the rest of the file once we've found the element
+                stopAfterPreVisit();
+                return tree;
+            }
+            return tree;
+        }
+
+        class LineLocatorPrinter extends PrintOutputCapture<P> {
+
+            public LineLocatorPrinter(P p) {
+                super(p);
+            }
+
+            @Override
+            public PrintOutputCapture<P> append(@Nullable String text) {
+                if (text == null) {
+                    return this;
+                }
+                for (int i = 0; i < text.length(); i++) {
+                    append(text.charAt(i));
+                }
+                return this;
+            }
+
+            @Override
+            public PrintOutputCapture<P> append(char c) {
+                if (isNewLine(c)) {
+                    foundLineNumber++;
+                }
+                // Actually appending isn't necessary
+                return this;
+            }
+        }
+    }
+
+    private static boolean isNewLine(int c) {
+        return c == '\n' || c == '\r';
+    }
+}

--- a/src/main/java/org/openrewrite/analysis/util/package-info.java
+++ b/src/main/java/org/openrewrite/analysis/util/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This package is used to analyze the dataflow through a program.
+ * <p>
+ * The primary entry point for interacting with this logic is
+ * {@link org.openrewrite.analysis.dataflow.Dataflow#startingAt(org.openrewrite.Cursor)}.
+ */
+@NonNullApi
+package org.openrewrite.analysis.util;
+
+import org.openrewrite.internal.lang.NonNullApi;

--- a/src/test/java/org/openrewrite/analysis/util/CoordinateLocatorTest.java
+++ b/src/test/java/org/openrewrite/analysis/util/CoordinateLocatorTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.util;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class CoordinateLocatorTest implements RewriteTest {
+
+    private static Supplier<TreeVisitor<?, ExecutionContext>> locateCoordinate(int line, int column) {
+        return () -> new JavaIsoVisitor<>() {
+
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                J found = CoordinateLocator.findCoordinate(cu, line, column).some();
+                //noinspection DataFlowIssue
+                return (J.CompilationUnit) cu.accept(new JavaIsoVisitor<>() {
+                    @Override
+                    public @Nullable J preVisit(J tree, ExecutionContext executionContext) {
+                        if (tree.isScope(found)) {
+                            return SearchResult.found(tree, tree.getClass().getSimpleName());
+                        }
+                        return super.preVisit(tree, executionContext);
+                    }
+                }, executionContext);
+            }
+        };
+    }
+
+    private static Supplier<TreeVisitor<?, ExecutionContext>> locateLine(int line) {
+        return () -> new JavaIsoVisitor<>() {
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                Collection<J> found = CoordinateLocator.findLine(cu, line);
+
+                //noinspection DataFlowIssue
+                return (J.CompilationUnit) cu.accept(new JavaIsoVisitor<>() {
+                    @Override
+                    public @Nullable J preVisit(J tree, ExecutionContext executionContext) {
+                        if (found.contains(tree)) {
+                            return SearchResult.found(tree, tree.getClass().getSimpleName());
+                        }
+                        return super.preVisit(tree, executionContext);
+                    }
+                }, executionContext);
+            }
+        };
+    }
+
+    @Test
+    void findCoordinatePassedString() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(locateCoordinate(3, 28))),
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      System.out.println(/*~~(Literal)~~>*/"Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findCoordinateMethodInvocation() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(locateCoordinate(3, 20))),
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      System.out./*~~(Identifier)~~>*/println("Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findMethodCallLineNumber() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(locateLine(3))),
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      /*~~(FieldAccess)~~>*//*~~(Identifier)~~>*/System./*~~(Identifier)~~>*/out./*~~(Identifier)~~>*/println(/*~~(Literal)~~>*/"Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findClassHeaderLine() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(locateLine(1))),
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              /*~~(ClassDeclaration)~~>*/class /*~~(Identifier)~~>*/Test /*~~(Block)~~>*/{
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findClassHeaderWithMultilneCommentLine() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(locateLine(1))),
+          java(
+            """
+              class Test /*
+              */ {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              /*~~(ClassDeclaration)~~>*/class /*~~(Identifier)~~>*/Test /*
+              */ {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
This allows for finding AST nodes that are flagged by other scanners to be identified within the OpenRewrite Java AST.

Unfortunately, since each printer is unique to each language, this logic as it is currently is not multi-language

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
