### PR TITLE
Simplify `InvocationMatcher` API

### DIFF
--- a/src/main/java/org/openrewrite/analysis/BasicInvocationMatcher.java
+++ b/src/main/java/org/openrewrite/analysis/BasicInvocationMatcher.java
@@ -17,11 +17,16 @@ package org.openrewrite.analysis;
 
 import io.micrometer.core.lang.Nullable;
 import lombok.NoArgsConstructor;
+import org.openrewrite.internal.LoathingOfOthers;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.List;
 
+/**
+ * @implNote Much of this logic is copied from {@link org.openrewrite.java.MethodMatcher}, but extracted as an interface.
+ */
+@LoathingOfOthers("org.openrewrite.java.MethodMatcher")
 public interface BasicInvocationMatcher extends InvocationMatcher {
 
     @Override
@@ -69,10 +74,4 @@ public interface BasicInvocationMatcher extends InvocationMatcher {
 
     boolean matchesParameterTypes(List<JavaType> parameterTypes);
 
-}
-
-@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
-final class SimpleMethodMatcherHolder {
-    static final JavaType.ShallowClass OBJECT_CLASS =
-            JavaType.ShallowClass.build("java.lang.Object");
 }

--- a/src/main/java/org/openrewrite/analysis/InvocationMatcher.java
+++ b/src/main/java/org/openrewrite/analysis/InvocationMatcher.java
@@ -73,6 +73,20 @@ public interface InvocationMatcher {
         return expression -> matchers.stream().anyMatch(matcher -> matcher.matches(expression));
     }
 
+    /**
+     * This method functions in the same way as <code>fromMethodMatcher(new MethodMatcher(methodName))</code>.
+     */
+    static InvocationMatcher fromMethodMatcher(String methodName) {
+        return fromMethodMatcher(new MethodMatcher(methodName));
+    }
+
+    /**
+     * This method functions in the same way as <code>fromMethodMatcher(new MethodMatcher(methodName, matchOverrides))</code>.
+     */
+    static InvocationMatcher fromMethodMatcher(String methodName, @Nullable Boolean matchOverrides) {
+        return fromMethodMatcher(new MethodMatcher(methodName, matchOverrides));
+    }
+
     static InvocationMatcher fromMethodMatcher(MethodMatcher methodMatcher) {
         return methodMatcher::matches;
     }
@@ -91,7 +105,7 @@ public interface InvocationMatcher {
 
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     final class AdvancedInvocationMatcher {
-        private InvocationMatcher matcher;
+        private final InvocationMatcher matcher;
 
         public boolean isSelect(Cursor cursor) {
             return asExpression(cursor, expression -> {

--- a/src/main/java/org/openrewrite/analysis/search/FindFlowBetweenMethods.java
+++ b/src/main/java/org/openrewrite/analysis/search/FindFlowBetweenMethods.java
@@ -70,12 +70,8 @@ public class FindFlowBetweenMethods extends ScanningRecipe<GlobalDataFlow.Accumu
 
     @Override
     public GlobalDataFlow.Accumulator getInitialValue(ExecutionContext ctx) {
-        InvocationMatcher startMatcher = InvocationMatcher.fromMethodMatcher(
-                new MethodMatcher(startMethodPattern, startMatchOverrides)
-        );
-        InvocationMatcher endMatcher = InvocationMatcher.fromMethodMatcher(
-                new MethodMatcher(endMethodPattern, endMatchOverrides)
-        );
+        InvocationMatcher startMatcher = InvocationMatcher.fromMethodMatcher(startMethodPattern, startMatchOverrides);
+        InvocationMatcher endMatcher = InvocationMatcher.fromMethodMatcher(endMethodPattern, endMatchOverrides);
 
         final Predicate<Cursor> sinkMatcher;
 
@@ -87,8 +83,9 @@ public class FindFlowBetweenMethods extends ScanningRecipe<GlobalDataFlow.Accumu
                 sinkMatcher = endMatcher.advanced()::isAnyArgument;
                 break;
             case "Both":
-                sinkMatcher = cursor -> endMatcher.advanced().isAnyArgument(cursor) ||
-                                        endMatcher.advanced().isSelect(cursor);
+                InvocationMatcher.AdvancedInvocationMatcher advanced = endMatcher.advanced();
+                sinkMatcher = cursor -> advanced.isAnyArgument(cursor) ||
+                                        advanced.isSelect(cursor);
                 break;
             default:
                 throw new IllegalStateException("Unknown target: " + target);

--- a/src/main/java/org/openrewrite/analysis/search/UriCreatedWithHttpScheme.java
+++ b/src/main/java/org/openrewrite/analysis/search/UriCreatedWithHttpScheme.java
@@ -28,12 +28,10 @@ import org.openrewrite.analysis.trait.expr.BinaryExpr;
 import org.openrewrite.analysis.trait.expr.Literal;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 
 public class UriCreatedWithHttpScheme extends Recipe {
-    private static final MethodMatcher URI_CREATE_METHOD_MATCHER = new MethodMatcher("java.net.URI create(..)");
-    private static final InvocationMatcher URI_CREATE = InvocationMatcher.fromMethodMatcher(URI_CREATE_METHOD_MATCHER);
+    private static final InvocationMatcher URI_CREATE = InvocationMatcher.fromMethodMatcher("java.net.URI create(..)");
     private static final MethodMatcher STRING_REPLACE = new MethodMatcher("java.lang.String replace(..)");
 
     private static final DataFlowSpec INSECURE_URI_CREATE = new DataFlowSpec() {
@@ -77,7 +75,7 @@ public class UriCreatedWithHttpScheme extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesMethod<>(URI_CREATE_METHOD_MATCHER), new JavaIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesInvocation<>(URI_CREATE), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.Literal visitLiteral(J.Literal literal, ExecutionContext ctx) {
                 J.Literal l = super.visitLiteral(literal, ctx);

--- a/src/main/java/org/openrewrite/analysis/search/UsesAllInvocations.java
+++ b/src/main/java/org/openrewrite/analysis/search/UsesAllInvocations.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.search;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.Tree;
+import org.openrewrite.analysis.InvocationMatcher;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Marks a {@link JavaSourceFile} as matching if all the passed methods are found.
+ */
+@RequiredArgsConstructor
+public class UsesAllInvocations<P> extends JavaIsoVisitor<P> {
+    private final List<InvocationMatcher> invocationMatchers;
+
+    public UsesAllInvocations(InvocationMatcher... invocationMatchers) {
+        this(Arrays.asList(invocationMatchers));
+    }
+
+    @Override
+    public J visit(@Nullable Tree tree, P p) {
+        if (tree instanceof JavaSourceFile) {
+            JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
+            List<InvocationMatcher> unmatched = new ArrayList<>(invocationMatchers);
+            for (JavaType.Method type : cu.getTypesInUse().getUsedMethods()) {
+                if (unmatched.removeIf(matcher -> matcher.matches(type)) && unmatched.isEmpty()) {
+                    return SearchResult.found(cu);
+                }
+            }
+        }
+        return (J) tree;
+    }
+}

--- a/src/main/java/org/openrewrite/analysis/search/UsesInvocation.java
+++ b/src/main/java/org/openrewrite/analysis/search/UsesInvocation.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.search;
+
+import org.openrewrite.Tree;
+import org.openrewrite.analysis.InvocationMatcher;
+import org.openrewrite.internal.LoathingOfOthers;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * Equivalent to {@link org.openrewrite.java.search.UsesMethod} but for any {@link InvocationMatcher}.
+ *
+ * @implNote If {@link org.openrewrite.java.MethodMatcher} were or had a base interface, this wouldn't be needed.
+ */
+@LoathingOfOthers("org.openrewrite.java.MethodMatcher")
+public class UsesInvocation<P> extends JavaIsoVisitor<P> {
+    private final InvocationMatcher invocationMatcher;
+
+    public UsesInvocation(InvocationMatcher invocationMatcher) {
+        this.invocationMatcher = invocationMatcher;
+    }
+
+    @Override
+    public J visit(@Nullable Tree tree, P p) {
+        if (tree instanceof JavaSourceFile) {
+            JavaSourceFile cu = (JavaSourceFile) tree;
+            for (JavaType.Method type : cu.getTypesInUse().getUsedMethods()) {
+                if (invocationMatcher.matches(type)) {
+                    return SearchResult.found(cu);
+                }
+            }
+            return (J) tree;
+        }
+        return super.visit(tree, p);
+    }
+
+    @Override
+    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {
+        if (invocationMatcher.matches(method)) {
+            return SearchResult.found(method);
+        }
+        return super.visitMethodInvocation(method, p);
+    }
+
+    @Override
+    public J.MemberReference visitMemberReference(J.MemberReference memberRef, P p) {
+        if (invocationMatcher.matches(memberRef)) {
+            return SearchResult.found(memberRef);
+        }
+        return super.visitMemberReference(memberRef, p);
+    }
+
+    @Override
+    public J.NewClass visitNewClass(J.NewClass newClass, P p) {
+        if (invocationMatcher.matches(newClass)) {
+            return SearchResult.found(newClass);
+        }
+        return super.visitNewClass(newClass, p);
+    }
+}

--- a/src/test/java/org/openrewrite/analysis/dataflow/global/GlobalDataFlowTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/global/GlobalDataFlowTest.java
@@ -32,7 +32,7 @@ public class GlobalDataFlowTest implements RewriteTest {
 
     static final DataFlowSpec DATA_FLOW_SPEC = new DataFlowSpec() {
         private static final InvocationMatcher SYSTEM_OUT_PRINTLN = InvocationMatcher.fromMethodMatcher(
-          new MethodMatcher("java.io.PrintStream println(..)")
+          "java.io.PrintStream println(..)"
         );
 
         @Override
@@ -64,7 +64,7 @@ public class GlobalDataFlowTest implements RewriteTest {
           java(
             """
               class Test {
-              
+                            
                   String identity(String s) {
                       return s;
                   }
@@ -78,7 +78,7 @@ public class GlobalDataFlowTest implements RewriteTest {
               """,
             """
               class Test {
-              
+                            
                   String identity(String /*~~>*/s) {
                       return /*~~>*/s;
                   }
@@ -100,7 +100,7 @@ public class GlobalDataFlowTest implements RewriteTest {
           java(
             """
               class Test {
-              
+                            
                   Object identity(Object s) {
                       return s;
                   }
@@ -114,7 +114,7 @@ public class GlobalDataFlowTest implements RewriteTest {
               """,
             """
               class Test {
-              
+                            
                   Object identity(Object /*~~>*/s) {
                       return /*~~>*/s;
                   }
@@ -173,7 +173,7 @@ public class GlobalDataFlowTest implements RewriteTest {
           java(
             """
               class Test {
-              
+                            
                   String noOp(String s) {
                       return "something else";
                   }
@@ -195,7 +195,7 @@ public class GlobalDataFlowTest implements RewriteTest {
           java(
             """
               class Test {
-              
+                            
                   void print(String s) {
                       System.out.println(s);
                   }
@@ -208,7 +208,7 @@ public class GlobalDataFlowTest implements RewriteTest {
               """,
             """
               class Test {
-              
+                            
                   void print(String /*~~>*/s) {
                       System.out.println(/*~~(sink)~~>*/s);
                   }
@@ -229,7 +229,7 @@ public class GlobalDataFlowTest implements RewriteTest {
           java(
             """
               class Test {
-              
+                            
                   String recursive(String s) {
                       if(s.length() > 0) {
                           return recursive(s.substring(1));
@@ -246,7 +246,7 @@ public class GlobalDataFlowTest implements RewriteTest {
               """,
             """
               class Test {
-              
+                            
                   String recursive(String /*~~>*/s) {
                       if(/*~~>*/s.length() > 0) {
                           return recursive(s.substring(1));
@@ -269,7 +269,7 @@ public class GlobalDataFlowTest implements RewriteTest {
     void stringNullCheck() {
         rewriteRun(
           java(
-                """
+            """
               class Test {
                   static String requireNonNull(String obj) {
                       if (obj == null)
@@ -313,7 +313,7 @@ public class GlobalDataFlowTest implements RewriteTest {
     void genericNullCheck() {
         rewriteRun(
           java(
-                """
+            """
               class Test {
                   static <T> T requireNonNull(T obj) {
                       if (obj == null)

--- a/src/test/java/org/openrewrite/analysis/dataflow/global/GlobalTaintFlowTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/global/GlobalTaintFlowTest.java
@@ -30,7 +30,7 @@ import static org.openrewrite.java.Assertions.java;
 public class GlobalTaintFlowTest implements RewriteTest {
     static final TaintFlowSpec TAINT_FLOW_SPEC = new TaintFlowSpec() {
         private static final InvocationMatcher SYSTEM_OUT_PRINTLN = InvocationMatcher.fromMethodMatcher(
-          new MethodMatcher("java.io.PrintStream println(..)")
+          "java.io.PrintStream println(..)"
         );
 
         @Override
@@ -122,7 +122,7 @@ public class GlobalTaintFlowTest implements RewriteTest {
           java(
             """
               import java.util.Objects;
-              
+                            
               class Test {
                   String stringSubstring(String s) {
                       return Objects.requireNonNull(s.substring(1));
@@ -136,7 +136,7 @@ public class GlobalTaintFlowTest implements RewriteTest {
               """,
             """
               import java.util.Objects;
-              
+                            
               class Test {
                   String stringSubstring(String /*~~>*/s) {
                       return /*~~>*/Objects.requireNonNull(/*~~>*//*~~>*/s.substring(1));
@@ -158,7 +158,7 @@ public class GlobalTaintFlowTest implements RewriteTest {
           java(
             """
               class Test {
-              
+                            
                   String stringFizzBuzz(String number) {
                       int n = Integer.parseInt(number);
                       if (n % 15 == 0) {
@@ -180,7 +180,7 @@ public class GlobalTaintFlowTest implements RewriteTest {
               """,
             """
               class Test {
-              
+                            
                   String stringFizzBuzz(String /*~~>*/number) {
                       int n = Integer.parseInt(/*~~>*/number);
                       if (n % 15 == 0) {
@@ -211,7 +211,7 @@ public class GlobalTaintFlowTest implements RewriteTest {
           java(
             """
               class Test {
-              
+                            
                   String recursive(String parameterS) {
                       if (parameterS.length() > 0) {
                           return recursive(parameterS.substring(1));
@@ -228,7 +228,7 @@ public class GlobalTaintFlowTest implements RewriteTest {
               """,
             """
               class Test {
-              
+                            
                   String recursive(String /*~~>*/parameterS) {
                       if (/*~~>*/parameterS.length() > 0) {
                           return /*~~>*/recursive(/*~~>*//*~~>*/parameterS.substring(1));

--- a/src/test/java/org/openrewrite/analysis/search/UsesAllInvocationsTest.java
+++ b/src/test/java/org/openrewrite/analysis/search/UsesAllInvocationsTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.analysis.InvocationMatcher;
+import org.openrewrite.internal.LoathingOfOthers;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+@LoathingOfOthers("This is basically a copy-paste of UsesAllMethodsTest.java in rewrite-java-test")
+public class UsesAllInvocationsTest implements RewriteTest {
+
+    @DocumentExample
+    @Test
+    void usesBothMethods() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new UsesAllInvocations<>(
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptyList()"),
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptySet()")
+          ))),
+          java(
+            """
+              import java.util.Collections;
+              class Test {
+                  {
+                      Collections.emptyList();
+                      Collections.emptySet();
+                  }
+              }
+              """,
+            """
+              /*~~>*/import java.util.Collections;
+              class Test {
+                  {
+                      Collections.emptyList();
+                      Collections.emptySet();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void usesNeitherMethods() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new UsesAllInvocations<>(
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptyList()"),
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptySet()")
+          ))),
+          java(
+            """
+              import java.util.Collections;
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void usesOneMethod() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new UsesAllInvocations<>(
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptyList()"),
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptySet()")
+          ))),
+          java(
+            """
+              import java.util.Collections;
+              class Test {
+                  {
+                      Collections.emptyList();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void usesBothExitEarlyMethods() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new UsesAllInvocations<>(
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptyList()"),
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptySet()")
+          ))),
+          java(
+            """
+              import java.util.Collections;
+              class Test {
+                  {
+                      Collections.emptyList();
+                      Collections.emptySet();
+                      System.out.println("Hello");
+                  }
+              }
+              """,
+            """
+              /*~~>*/import java.util.Collections;
+              class Test {
+                  {
+                      Collections.emptyList();
+                      Collections.emptySet();
+                      System.out.println("Hello");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void matchesMultipleMethods() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new UsesAllInvocations<>(
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptyList()"),
+            InvocationMatcher.fromMethodMatcher("java.util.Collections *()"),
+            InvocationMatcher.fromMethodMatcher("java.util.Collections emptySet()")
+          ))),
+          java(
+            """
+              import java.util.Collections;
+              class Test {
+                  {
+                      Collections.emptyList();
+                      Collections.emptySet();
+                  }
+              }
+              """,
+            """
+              /*~~>*/import java.util.Collections;
+              class Test {
+                  {
+                      Collections.emptyList();
+                      Collections.emptySet();
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
Makes `InvocationMatcher` easier to use directly instead of needing
to hold an instance of `MethodMatcher` independent from `InvocationMatcher`.

Basically everythig in `rewrite-java-security` and anything using `rewrite-analysis`
needs to use `InvocationMatcher` instead of `MethodMatcher` so this makes it easier to
use `InvocationMatcher` exclusively.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
