### PR TITLE
fix: FlowPath Analysis with chained lambda expressions

### DIFF
--- a/src/main/java/org/openrewrite/analysis/util/CursorUtil.java
+++ b/src/main/java/org/openrewrite/analysis/util/CursorUtil.java
@@ -38,7 +38,7 @@ public class CursorUtil {
             Object next = nextCursor.getValue();
             if (next instanceof J.Block) {
                 methodDeclarationBlockCursor = nextCursor;
-                if (J.Block.isStaticOrInitBlock(nextCursor)) {
+                if (J.Block.isStaticOrInitBlock(nextCursor) || nextCursor.getParentTreeCursor().getValue() instanceof J.Lambda) {
                     return Option.some(nextCursor);
                 }
             } else if (next instanceof J.MethodDeclaration) {


### PR DESCRIPTION
## What's changed?
Flow path analysis currently fails for chained lambda expressions. The issue occurs because the lambda end is marked as [ControlFlowNode.End](https://github.com/openrewrite/rewrite-analysis/blob/2989d87351cdd98e5d12f00e244813ae8c046914/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowSummary.java#L109), resulting in subsequent lambdas in the chain being skipped.

To resolve this, the lambda body is now marked as the start node when identifying flow paths for expressions within it. This approach eliminates the need to search for flow paths outside the lambda body, as per [JLS §15.27.2](https://docs.oracle.com/javase/specs/jls/se10/html/jls-15.html#jls-15.27.2), can be inferred  that expressions within a lambda body cannot assign values to variables declared outside of the lambda body.

## What's your motivation?
- resolves #72 


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
