### PR TITLE
Account for expression not having a Block parent

### DIFF
--- a/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
@@ -101,7 +101,7 @@ public class ForwardFlow extends JavaVisitor<Integer> {
         } else {
             // This is when assignment occurs within the body of a block
             assert taintStmt != null : "taintStmt is null";
-            Cursor c = root.getNode().getCursor().dropParentUntil(v -> J.Block.class.isInstance(v) || J.CompilationUnit.class.isInstance(v));
+            Cursor c = root.getNode().getCursor().dropParentUntil(v -> v instanceof J.Block || v instanceof J.CompilationUnit);
             if (c.getValue() instanceof J.Block) {
                 visitBlocksRecursive(c, taintStmt, analysis);
             }

--- a/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
@@ -101,7 +101,10 @@ public class ForwardFlow extends JavaVisitor<Integer> {
         } else {
             // This is when assignment occurs within the body of a block
             assert taintStmt != null : "taintStmt is null";
-            visitBlocksRecursive(root.getNode().getCursor().dropParentUntil(J.Block.class::isInstance), taintStmt, analysis);
+            Cursor c = root.getNode().getCursor().dropParentUntil(v -> J.Block.class.isInstance(v) || J.CompilationUnit.class.isInstance(v));
+            if (c.getValue() instanceof J.Block) {
+                visitBlocksRecursive(c, taintStmt, analysis);
+            }
         }
     }
 

--- a/src/test/java/org/openrewrite/analysis/search/FindFlowBetweenMethodsTest.java
+++ b/src/test/java/org/openrewrite/analysis/search/FindFlowBetweenMethodsTest.java
@@ -316,4 +316,28 @@ class FindFlowBetweenMethodsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void expressionInAnnotationOverClass() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFlowBetweenMethods(
+              "java.util.LinkedList <constructor>()",
+              true,
+              "java.util.LinkedList remove()",
+              true,
+              "Both",
+              "Taint"
+            )
+          ),
+          //language=java
+          java(
+            """
+              @Deprecated(since = "now")
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
Blows up on annotation parameter where annotation is over class, i.e. there is no block in expression ancestry.