### PR TITLE
Prevent potential Java 21 issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,16 +31,9 @@ dependencies {
     testImplementation("org.assertj:assertj-core:latest.release")
 
     testRuntimeOnly("org.openrewrite:rewrite-java-17:${rewriteVersion}")
-    testRuntimeOnly("org.openrewrite:rewrite-java-21:${rewriteVersion}")
 
     testRuntimeOnly("commons-io:commons-io:2.13.+")
     testRuntimeOnly("com.google.guava:guava:32.1.1-jre")
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
 }
 
 tasks.withType<Javadoc> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,9 +31,16 @@ dependencies {
     testImplementation("org.assertj:assertj-core:latest.release")
 
     testRuntimeOnly("org.openrewrite:rewrite-java-17:${rewriteVersion}")
+    testRuntimeOnly("org.openrewrite:rewrite-java-21:${rewriteVersion}")
 
     testRuntimeOnly("commons-io:commons-io:2.13.+")
     testRuntimeOnly("com.google.guava:guava:32.1.1-jre")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
 }
 
 tasks.withType<Javadoc> {

--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
@@ -348,7 +348,7 @@ public final class ControlFlow {
                                 return super.visitCase(_case, p);
                             }
                             // TODO: Handle complex conditional expressions in case statements (ie. Java 17 pattern matching)
-                            // visit(_case.getExpressions(), p);
+                            // visit(_case.getCaseLabels(), p);
                             addCursorToBasicBlock();
                             ControlFlowNode.ConditionNode conditionNode = currentAsBasicBlock().addConditionNodeTruthFirst();
                             current = Stream.concat(Stream.of(conditionNode), caseFlow.stream()).collect(Collectors.toSet());
@@ -953,7 +953,7 @@ public final class ControlFlow {
          * @return true if this case is the default case.
          */
         private static boolean isDefaultCase(J.Case _case) {
-            List<Expression> expressions = _case.getExpressions();
+            List<J> expressions = _case.getCaseLabels();
             return expressions.size() == 1 &&
                    expressions.get(0) instanceof J.Identifier &&
                    "default".equals(((J.Identifier) expressions.get(0)).getSimpleName());

--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowNode.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowNode.java
@@ -303,8 +303,8 @@ public abstract class ControlFlowNode {
                             .flatMap(v -> {
                                 if (v instanceof J.Case) {
                                     J.Case caseStatement = (J.Case) v;
-                                    if (caseStatement.getExpressions().size() == 1 && caseStatement.getExpressions().get(0) instanceof J.Literal) {
-                                        return Stream.of(v, caseStatement.getExpressions().get(0));
+                                    if (caseStatement.getCaseLabels().size() == 1 && caseStatement.getCaseLabels().get(0) instanceof J.Literal) {
+                                        return Stream.of(v, caseStatement.getCaseLabels().get(0));
                                     }
                                 }
                                 return Stream.of(v);


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Apply newest `getCaseLabel` instead of `getExpression`

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
