### PR TITLE
Added context to TraitErrorsException and made it publicly available

### DIFF
--- a/src/main/java/org/openrewrite/analysis/trait/util/TraitErrorsException.java
+++ b/src/main/java/org/openrewrite/analysis/trait/util/TraitErrorsException.java
@@ -15,8 +15,14 @@
  */
 package org.openrewrite.analysis.trait.util;
 
-class TraitErrorsException extends RuntimeException {
+import lombok.Getter;
+
+@Getter
+public class TraitErrorsException extends RuntimeException {
+    private final TraitErrors errors;
+
     TraitErrorsException(TraitErrors traitErrors) {
         super(traitErrors.toString());
+        this.errors = traitErrors;
     }
 }


### PR DESCRIPTION
In order to be able to ignore certain error in try catch blocks, it would be useful if we can have this class publicly available + offer the errors passed in as context to the exception and not only to its message. 