### PR TITLE
Fix `ThisAccess` to actually match `this` expressions

### DIFF
--- a/src/main/java/org/openrewrite/analysis/trait/expr/ThisAccess.java
+++ b/src/main/java/org/openrewrite/analysis/trait/expr/ThisAccess.java
@@ -38,7 +38,7 @@ public interface ThisAccess extends InstanceAccess {
         public Validation<TraitErrors, ThisAccess> viewOf(Cursor cursor) {
             return InstanceAccessBase.viewOf(cursor)
                     .bind(iab -> {
-                if ("super".equals(iab.getName())) {
+                if ("this".equals(iab.getName())) {
                     return Validation.success(new ThisAccessBase(iab));
                 }
                 return TraitErrors.invalidTraitCreationError("Instance Access is not a This Access");

--- a/src/test/java/org/openrewrite/analysis/dataflow/DataFlowNodeTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/DataFlowNodeTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -86,6 +87,47 @@ class DataFlowNodeTest implements RewriteTest {
             import java.util.*;
             class A {}
             """
+          )
+        );
+    }
+
+    @Test
+    void thisIsADataFlowNode() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new TreeVisitor<>() {
+              @Override
+              public @Nullable Tree preVisit(Tree tree, ExecutionContext executionContext) {
+                  Tree t = super.preVisit(tree, executionContext);
+                  if (tree instanceof J.Identifier && "this".equals(((J.Identifier) tree).getSimpleName())) {
+                      return DataFlowNode
+                        .of(getCursor())
+                        .map(df -> (Tree) SearchResult.found(t))
+                        .orSome(t);
+                  }
+                  return t;
+              }
+          })),
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+              class A {
+                  void test() {
+                      List<A> result = new ArrayList<>();
+                      result.add(this);
+                  }
+              }
+              """,
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+              class A {
+                  void test() {
+                      List<A> result = new ArrayList<>();
+                      result.add(/*~~>*/this);
+                  }
+              }
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/analysis/dataflow/FindLocalFlowPathsStringTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/FindLocalFlowPathsStringTest.java
@@ -2010,4 +2010,32 @@ class FindLocalFlowPathsStringTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void flowWhereThisIsAnotherArgument() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void consume(String s, Test t) {
+                  }
+                  void test() {
+                      String n = "42";
+                      consume(n, this);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void consume(String s, Test t) {
+                  }
+                  void test() {
+                      String n = /*~~>*/"42";
+                      consume(/*~~>*/n, this);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Motivation

The `ThisAccess.Factory.viewOf` factory — meant to create a trait view for `this` identifiers — checked for the string `"super"` instead of `"this"`. As a result, `Expr.viewOf(cursor)` never resolved for a `this` identifier; every `this` expression fell through the trait factory chain:
- `ThisAccess` rejected `this` (because it was looking for `super`)
- `SuperAccess` also rejected `this`
- `VarAccess` doesn't handle `this`
- `ExprFallback` explicitly rejects `J.Identifier`

So `DataFlowNode.of(cursor)` returned `none` for any `this` identifier. `ForwardFlow.computeVariableAssignment` then threw `Unable to create DataFlowNode` via `ofOrThrow` whenever the algorithm iterated method-invocation arguments and encountered `this`. This broke any downstream recipe relying on local dataflow (for example `ReplaceStackWithDeque`) on code that passed `this` into a method call along a tracked flow path.

Originally surfaced as a crash in `ReplaceStackWithDeque` on real-world code in `finos/messageml-utils` and `finos/tracdap` where `result.add(this)` and `validator.apply(target, arg, this)` appeared in the same method as a `Stack` variable.

## Summary

- Correct the literal comparison in `ThisAccess.Factory.viewOf` from `"super"` to `"this"`
- Add `DataFlowNodeTest.thisIsADataFlowNode` — verifies `DataFlowNode.of` now resolves for a `this` identifier
- Add `FindLocalFlowPathsStringTest.flowWhereThisIsAnotherArgument` — regression test that crashes before this fix (identical `Unable to create DataFlowNode` stack trace) and passes after

## Test plan

- [x] `./gradlew test` passes with the fix
- [x] Reverting only the one-line fix causes `FindLocalFlowPathsStringTest.flowWhereThisIsAnotherArgument` to fail with the original production stack trace (`DataFlowNode.ofOrThrow` → `ForwardFlow.computeVariableAssignment:467`)
- [x] Verified against a `ReplaceStackWithDeque` reproducer (rewrite-static-analysis) that previously crashed on `result.add(this)` — recipe now runs cleanly after publishing this change to Maven Local