### PR TITLE
Fix ControlFlow crashes on multi-method anon classes and Kotlin booleans

### DIFF
--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
@@ -895,6 +895,20 @@ public final class ControlFlow {
         }
 
         @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, P p) {
+            // Method declarations encountered here are nested (e.g. inside an anonymous
+            // class body). Each one is its own callable, so analyze the body as a
+            // separate sub-flow — analogous to how `visitLambda` handles a lambda body.
+            addCursorToBasicBlock();
+            if (method.getBody() != null) {
+                ControlFlowSimpleSummary summary = findControlFlowInternal(new Cursor(getCursor(), method.getBody()), ControlFlowNode.GraphType.LAMBDA);
+                currentAsBasicBlock().addSuccessor(summary.start);
+                current = singleton(summary.end);
+            }
+            return method;
+        }
+
+        @Override
         public J.Empty visitEmpty(J.Empty empty, P p) {
             J.MethodInvocation parent = getCursor().firstEnclosing(J.MethodInvocation.class);
             if (parent != null && parent.getArguments().contains(empty)) {

--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowSummary.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowSummary.java
@@ -103,11 +103,12 @@ public final class ControlFlowSummary {
         final Queue<ControlFlowNode> toVisit = new LinkedList<>();
         if (visit instanceof ControlFlowNode.ConditionNode) {
             toVisit.addAll(((ControlFlowNode.ConditionNode) visit).visit(predicate));
-        } else if (!(visit instanceof ControlFlowNode.End)) {
-            toVisit.addAll(visit.getSuccessors());
         } else {
-            // End node does not need to be visited
-            return;
+            // For LAMBDA-typed End nodes (used for lambda bodies and anonymous class
+            // bodies), `getSuccessors()` returns the node that follows the sub-flow in
+            // the surrounding control flow, so traversal must continue. METHOD-typed
+            // Ends always return an empty set, so this branch is a no-op for them.
+            toVisit.addAll(visit.getSuccessors());
         }
         toVisit.removeAll(reachable);
         toVisit.forEach(n -> recurseComputeReachableBasicBlock(n, predicate, reachable));

--- a/src/main/java/org/openrewrite/analysis/controlflow/Guard.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/Guard.java
@@ -70,11 +70,21 @@ public final class Guard {
         }
         return getTypeSafe(cursor, e)
                 .map(type -> {
-            if (TypeUtils.isAssignableTo(JavaType.Primitive.Boolean, type)) {
+            if (isBooleanLike(type)) {
                 return new Guard(cursor, e, null);
             }
             return null;
         });
+    }
+
+    private static boolean isBooleanLike(@Nullable JavaType type) {
+        if (TypeUtils.isAssignableTo(JavaType.Primitive.Boolean, type)) {
+            return true;
+        }
+        // Kotlin's `kotlin.Boolean` is represented as a FullyQualified type that
+        // `TypeUtils.isAssignableTo` does not recognise as boolean. Accept it here so
+        // Kotlin sources work.
+        return TypeUtils.isOfClassType(type, "kotlin.Boolean");
     }
 
     private static Optional<J.ControlParentheses<?>> getControlParenthesesFromParent(Cursor cursor) {
@@ -131,7 +141,7 @@ public final class Guard {
 
     private static Optional<JavaType> getTypeSafe(Cursor c, Expression e) {
         JavaType type = e.getType();
-        if (type != null && !JavaType.Unknown.getInstance().equals(type)) {
+        if (type != null && !JavaType.Unknown.getInstance().equals(type) && isBooleanLike(type)) {
             return Optional.of(type);
         }
         if (e instanceof J.Binary) {
@@ -161,6 +171,15 @@ public final class Guard {
             if ("equals".equals(methodInvocation.getSimpleName())) {
                 return Optional.of(JavaType.Primitive.Boolean);
             }
+            if (methodInvocation.getMethodType() != null) {
+                JavaType returnType = methodInvocation.getMethodType().getReturnType();
+                if (isBooleanLike(returnType)) {
+                    return Optional.of(returnType);
+                }
+            }
+        }
+        if (type != null && !JavaType.Unknown.getInstance().equals(type)) {
+            return Optional.of(type);
         }
         J firstEnclosing = c.getParentOrThrow().firstEnclosing(J.class);
         if (firstEnclosing instanceof J.Binary) {

--- a/src/test/java/org/openrewrite/analysis/dataflow/FindLocalFlowPathsAnonymousClassTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/FindLocalFlowPathsAnonymousClassTest.java
@@ -392,4 +392,56 @@ class FindLocalFlowPathsAnonymousClassTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void anonymousClassWithMultipleAnnotatedMethods() {
+        // Regression: ControlFlow used to throw "No current node!" when an anonymous
+        // class body contained multiple method declarations and the first one's body
+        // ended in a `return`. The return cleared `current`, so visiting the second
+        // method's leading `@Override` annotation tripped `currentAsBasicBlock()`.
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Object test() {
+                      String o = "42";
+                      Object r = new Object() {
+                          @Override
+                          public boolean equals(Object obj) {
+                              System.out.println(o);
+                              return obj == this;
+                          }
+
+                          @Override
+                          public String toString() {
+                              return "r";
+                          }
+                      };
+                      return r;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  Object test() {
+                      String o = /*~~>*/"42";
+                      Object r = new Object() {
+                          @Override
+                          public boolean equals(Object obj) {
+                              System.out.println(/*~~>*/o);
+                              return obj == this;
+                          }
+
+                          @Override
+                          public String toString() {
+                              return "r";
+                          }
+                      };
+                      return r;
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Motivation

Three independent issues surfaced as `ControlFlowIllegalStateException`s thrown from the `ControlFlow` analyzer that powers `Dataflow` / `FindLocalFlowPaths` and, transitively, recipes like `org.openrewrite.staticanalysis.ReplaceStackWithDeque`. Reproduced on flagship runs of the "OpenRewrite recipe best practices" recipe (2026-05-05 and 2026-05-06) against:

- `moderneinc/moderne-intellij-plugin` (Kotlin) — `Condition Node is not a guard!`
- `moderneinc/rewrite-sql` (Java) — `No current node!`
- `openrewrite/rewrite-templating` (Java) — `No current node!`

Each surfaces inside `ReplaceStackWithDeque.visitVariable` → `FindLocalFlowPaths.noneMatch` → `ControlFlow.startingAt(...).findControlFlow()`.

## Summary

1. **`No current node!`** when an anonymous class body contained more than one method and the first one's body ended in a `return`. The default `JavaIsoVisitor` walked the inner method declaration as part of the enclosing flow, so `visitReturn` cleared `current`, and the next method's leading `@Override` annotation tripped `currentAsBasicBlock()`. Override `visitMethodDeclaration` in `ControlFlowAnalysis` to analyze each nested method body as its own sub-flow — the same way `visitLambda` already handles a lambda body.

- 2. **Reachability stopped at lambda / anonymous-class `End` nodes.** Once #95 started recursing into anonymous class bodies, code that appeared *after* an anonymous class (or a block-body lambda) stopped being marked reachable, because `recurseComputeReachableBasicBlock` returned early on every `End`. `LAMBDA`-typed `End` nodes do have a successor in the surrounding flow; `METHOD`-typed `End` nodes return an empty successor set anyway, so just always traverse the successors.

3. **`Condition Node is not a guard!`** for Kotlin sources because `kotlin.Boolean` is modelled as a `JavaType.FullyQualified` and `TypeUtils.isAssignableTo(Primitive.Boolean, kotlin.Boolean)` returns false. Recognize `kotlin.Boolean` as boolean-like in `Guard.from`, and consult the method-invocation return type for cases like `someStack.contains(x)`.

## Test plan

- [x] Added regression test `anonymousClassWithMultipleAnnotatedMethods` in `FindLocalFlowPathsAnonymousClassTest` (reproduces case 1 verbatim, also exercises case 2 by checking that the captured `o` reference inside the first method body is tracked).
- [x] Verified that the fix unblocks `org.openrewrite.staticanalysis.ReplaceStackWithDeque` against minimized versions of all three failing repos (separate PR in `rewrite-static-analysis`).
- [x] Full `rewrite-analysis` test suite still passes (`./gradlew test`).