### PR TITLE
Fix `ControlFlow` crash on Kotlin `expr ?: return` initializers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     testImplementation("org.openrewrite:rewrite-test:${rewriteVersion}")
     testImplementation("org.openrewrite:rewrite-java-tck:${rewriteVersion}")
+    testImplementation("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.14.2")
     testImplementation("com.tngtech.archunit:archunit-junit5:latest.release")
 

--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
@@ -211,10 +211,14 @@ public final class ControlFlow {
                 continueFlow.addAll(analysis.continueFlow);
                 breakFlow.addAll(analysis.breakFlow);
                 exitFlow.addAll(analysis.exitFlow);
-                if (current.isEmpty() && statement instanceof J.Try) {
-                    // TODO: Support try-catch blocks properly.
-                    // This case occurs when a try block has exhaustive exits,
-                    // and catch blocks handle errors gracefully
+                if (current.isEmpty()) {
+                    // The statement ended in an exhaustive exit — either at the
+                    // top level (return/throw) or inside a sub-expression (e.g.
+                    // Kotlin's `val x = expr ?: return X`, where the Elvis right
+                    // side performs the exit). No subsequent statement has a
+                    // continuation to feed into.
+                    // TODO: Support try-catch blocks where catches handle errors
+                    // gracefully — those should re-enter flow rather than break.
                     break;
                 }
             }
@@ -298,15 +302,27 @@ public final class ControlFlow {
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, P p) {
             visit(multiVariable.getTypeExpression(), p);
             for (J.VariableDeclarations.NamedVariable variable : multiVariable.getVariables()) {
+                if (current.isEmpty()) {
+                    // A previous variable's initializer exhaustively exited.
+                    return multiVariable;
+                }
                 visit(variable, p);
             }
-            addCursorToBasicBlock(); // Then the variable declaration
+            if (!current.isEmpty()) {
+                addCursorToBasicBlock(); // Then the variable declaration
+            }
             return multiVariable;
         }
 
         @Override
         public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, P p) {
             visit(variable.getInitializer(), p); // First add the initializer
+            if (current.isEmpty()) {
+                // The initializer exhaustively exited (e.g. Kotlin's
+                // `val x = expr ?: return`). Skip the name and the basic-block
+                // closure since there is no flow to attach them to.
+                return variable;
+            }
             visit(variable.getName(), p); // Then add the name
             addCursorToBasicBlock(); // Then add the variable declaration
             return variable;

--- a/src/test/java/org/openrewrite/analysis/dataflow/FindLocalFlowPathsKotlinTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/FindLocalFlowPathsKotlinTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.dataflow;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.analysis.trait.expr.Literal;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * Regression tests covering Kotlin sources where ControlFlow analysis used to
+ * crash with {@code ControlFlowIllegalStateException: No current node!}.
+ */
+class FindLocalFlowPathsKotlinTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new FindLocalFlowPaths<>(new DataFlowSpec() {
+            @Override
+            public boolean isSource(DataFlowNode srcNode) {
+                return srcNode
+                  .asExpr(Literal.class)
+                  .bind(Literal::getValue)
+                  .map("42"::equals)
+                  .orSome(false);
+            }
+
+            @Override
+            public boolean isSink(DataFlowNode sinkNode) {
+                return true;
+            }
+        })));
+    }
+
+    @Test
+    void elvisReturnInVariableInitializer() {
+        // Regression: ControlFlow used to throw "No current node!" when a Kotlin
+        // method body contained `val x = expr ?: return ...`. The Elvis right side
+        // contains a `return`, which clears `current`, so the trailing variable
+        // name (or any subsequent statement) tripped `currentAsBasicBlock()`.
+        // Observed on the 2026-05-07 flagship run against
+        // moderneinc/moderne-intellij-plugin (RecipeUtils.kt).
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              object Foo {
+                  fun problematic(items: List<String>?): Boolean {
+                      if (items == null) return false
+                      val first = items.firstOrNull() ?: return false
+                      return first.isNotEmpty()
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void elvisThrowInVariableInitializer() {
+        // Same shape but with `throw` instead of `return`.
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              object Foo {
+                  fun problematic(items: List<String>?): Int {
+                      val first = items?.firstOrNull() ?: throw IllegalArgumentException("empty")
+                      return first.length
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

- A flagship recipe run (2026-05-07, `OpenRewrite recipe best practices` against `moderneinc/moderne-intellij-plugin`) surfaced a fourth variant of `ControlFlowIllegalStateException: No current node!` that #96 did not cover:

```
ControlFlowIllegalStateException: No current node!
  AST: first
  Cursor: Cursor{Identifier->NamedVariable->VariableDeclarations->Block
    ->MethodDeclaration{Foo{name=problematic,return=boolean,
       parameters=[kotlin.collections.List<kotlin.String>]}}->...}
```

- #96 fixed `No current node!` for anonymous classes whose first method body ended in `return`. This case is different: a Kotlin top-level method whose body uses the very common `val x = expr ?: return ...` pattern. The Elvis right side performs a `return` (or `throw`), which clears `current` while the variable initializer is still being walked. Visiting the variable's name (or any subsequent statement) then trips `currentAsBasicBlock()` with `current = ∅`.

`ReplaceStackWithDeque` invokes `FindLocalFlowPaths` on every variable in any file that uses `Stack`, so a single Stack reference anywhere in a Kotlin file means every method body — including those with the Elvis-return idiom — is fed through `ControlFlow`.

## Examples

```kotlin
object Foo {
    fun problematic(items: List<String>?): Boolean {
        if (items == null) return false
        val first = items.firstOrNull() ?: return false   // crashed here
        return first.isNotEmpty()
    }
}
```

```kotlin
object Foo {
    fun problematic(items: List<String>?): Int {
        val first = items?.firstOrNull() ?: throw IllegalArgumentException("empty")
        return first.length
    }
}
```

## Summary

- `visitVariable`: skip the name visit (and the trailing `addCursorToBasicBlock`) when the initializer left `current` empty — there is no flow to attach them to.
- `visitVariableDeclarations`: break out of the named-variable loop once `current` is empty, and avoid the trailing `addCursorToBasicBlock` in that case.
- `visitStatementList`: generalize the existing `current.isEmpty() && statement instanceof J.Try` early break to *any* exhaustive exit. Once `current = ∅`, no continuation feeds into the next statement, so revisiting it would only crash.

## Test plan

- [x] Added `FindLocalFlowPathsKotlinTest` with two regressions (Elvis-return and Elvis-throw initializers).
- [x] Full `rewrite-analysis` test suite passes (`./gradlew test`).
- [x] Verified the existing flagship reproducer (`moderne-intellij-plugin/RecipeUtils.kt` shape) no longer crashes when consumed via `rewrite-static-analysis`'s `ReplaceStackWithDeque`.