### PR TITLE
Fix compilation: restore `(Object)` cast on ambiguous `append` call

### DIFF
--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowIllegalStateException.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowIllegalStateException.java
@@ -90,7 +90,7 @@ final class ControlFlowIllegalStateException extends IllegalStateException {
         private String createMessage() {
             StringBuilder sb = new StringBuilder(message);
             if (cursor != null) {
-                sb.append("\n\tAST: ").append(cursor.getValue());
+                sb.append("\n\tAST: ").append((Object) cursor.getValue());
                 sb.append("\n\tCursor: ").append(cursor);
             }
             nodes.forEach((key, node) ->


### PR DESCRIPTION
## Summary

Commit 50e6aed80 ("OpenRewrite recipe best practices") removed an `(Object)` cast that was not actually redundant, breaking the build on `main` ([failing run](https://github.com/openrewrite/rewrite-analysis/actions/runs/25959645820/job/76312668086)). `Cursor.getValue()` returns generic `<T> T`, which makes `StringBuilder.append` ambiguous between the `String`, `CharSequence`, and `Object` overloads. Restoring the cast fixes the single compile error.

## Test plan

- [x] `./gradlew compileJava` succeeds locally