### PR TITLE
Support lambda parameters in data flow analysis

### DIFF
--- a/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
@@ -59,11 +59,20 @@ public class ForwardFlow extends JavaVisitor<Integer> {
             taintStmtCursorParentParent = variableNameToFlowGraph.currentCursor.getParent();
             taintStmtCursorParent = variableNameToFlowGraph.currentCursor;
         }
+        boolean rootIsParameter = root.getNode().isParameter();
         Iterator<Cursor> remainingPath = variableNameToFlowGraph.remainingCursorPath;
         while (remainingPath.hasNext()) {
             taintStmtCursorParentParent = remainingPath.next();
             Object next = taintStmtCursorParentParent.getValue();
             if (next instanceof J.Block) {
+                break;
+            }
+            // A lambda parameter is in scope within the lambda body, which is reached by walking up
+            // through the lambda (NamedVariable -> VariableDeclarations -> Lambda.Parameters -> Lambda)
+            // rather than down into a method body. Stop at the lambda so its body becomes the scope.
+            if (rootIsParameter && next instanceof J.Lambda) {
+                taintStmt = next;
+                taintStmtCursorParent = taintStmtCursorParentParent;
                 break;
             }
             if (next instanceof J) {
@@ -100,6 +109,12 @@ public class ForwardFlow extends JavaVisitor<Integer> {
             J.MethodDeclaration methodDeclaration = (J.MethodDeclaration) taintStmt;
             assert taintStmtCursorParent.getValue() instanceof J.MethodDeclaration : "taintStmtCursorParent is not a method declaration";
             analysis.visit(methodDeclaration.getBody(), 0, taintStmtCursorParent);
+        } else if (taintStmt instanceof J.Lambda) {
+            // The source is a lambda parameter; flow begins in the lambda body, which may be a
+            // single expression or a block.
+            J.Lambda lambda = (J.Lambda) taintStmt;
+            assert taintStmtCursorParent.getValue() instanceof J.Lambda : "taintStmtCursorParent is not a lambda";
+            analysis.visit(lambda.getBody(), 0, taintStmtCursorParent);
         } else {
             // This is when assignment occurs within the body of a block
             assert taintStmt != null : "taintStmt is null";

--- a/src/main/java/org/openrewrite/analysis/trait/expr/FunctionalExpr.java
+++ b/src/main/java/org/openrewrite/analysis/trait/expr/FunctionalExpr.java
@@ -18,17 +18,26 @@ package org.openrewrite.analysis.trait.expr;
 import fj.data.Validation;
 import org.openrewrite.Cursor;
 import org.openrewrite.analysis.trait.TraitFactory;
+import org.openrewrite.analysis.trait.member.Method;
 import org.openrewrite.analysis.trait.util.TraitErrors;
 
 /**
  * A functional expression is either a lambda expression or a member reference expression.
  */
 public interface FunctionalExpr extends ClassInstanceExpr {
+
+    /**
+     * Gets the implicit method corresponding to this functional expression. The parameters of the
+     * functional expression are the parameters of this method, and its body is the method body.
+     */
+    Method asMethod();
+
     enum Factory implements TraitFactory<FunctionalExpr> {
         F;
 
         @Override
         public Validation<TraitErrors, FunctionalExpr> viewOf(Cursor cursor) {
+            // TODO: also resolve member reference expressions (the other kind of FunctionalExpr).
             return TraitFactory.findFirstViewOf(
                     cursor,
                     LambdaExpr.Factory.F

--- a/src/main/java/org/openrewrite/analysis/trait/expr/LambdaExpr.java
+++ b/src/main/java/org/openrewrite/analysis/trait/expr/LambdaExpr.java
@@ -22,6 +22,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.analysis.InvocationMatcher;
 import org.openrewrite.analysis.trait.Top;
 import org.openrewrite.analysis.trait.TraitFactory;
+import org.openrewrite.analysis.trait.member.Method;
 import org.openrewrite.analysis.trait.util.TraitErrors;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -65,8 +66,13 @@ class LambdaExprBase extends Top.Base implements LambdaExpr {
     }
 
     @Override
+    public Method asMethod() {
+        return Method.viewOf(cursor).on(TraitErrors::doThrow);
+    }
+
+    @Override
     public Option<JavaType.Method> getMethodType() {
-        return Option.none();
+        return asMethod().getMethodType();
     }
 
     static Validation<TraitErrors, LambdaExprBase> viewOf(Cursor cursor) {

--- a/src/main/java/org/openrewrite/analysis/trait/member/Method.java
+++ b/src/main/java/org/openrewrite/analysis/trait/member/Method.java
@@ -24,6 +24,7 @@ import org.openrewrite.analysis.trait.TraitFactory;
 import org.openrewrite.analysis.trait.util.TraitErrors;
 import org.openrewrite.analysis.trait.variable.Parameter;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 
@@ -43,6 +44,15 @@ public interface Method extends Callable {
         public Validation<TraitErrors, Method> viewOf(Cursor cursor) {
             if (cursor.getValue() instanceof J.MethodDeclaration) {
                 return Validation.success(new MethodDeclarationMethod(
+                        cursor,
+                        cursor.getValue()
+                ));
+            }
+            if (cursor.getValue() instanceof J.Lambda) {
+                // A lambda expression's implicit method corresponds to the single abstract method
+                // of its functional interface; the lambda's parameters are the parameters of this
+                // method and the lambda body is the method body. See {@code LambdaExpr#asMethod()}.
+                return Validation.success(new LambdaMethod(
                         cursor,
                         cursor.getValue()
                 ));
@@ -90,18 +100,106 @@ class MethodDeclarationMethod extends Top.Base implements Method {
     private static List<Parameter> collectParameters(Cursor cursor, J.MethodDeclaration methodDeclaration) {
         assert cursor.getValue() == methodDeclaration;
         List<Parameter> parameters = new ArrayList<>(methodDeclaration.getParameters().size());
-        new JavaVisitor<List<Parameter>>() {
-            {
-                // Correctly set the parent cursor for the parameters
-                setCursor(cursor);
-            }
-
-            @Override
-            public J visitVariable(J.VariableDeclarations.NamedVariable variable, List<Parameter> parameters) {
-                parameters.add(Parameter.viewOf(getCursor()).on(TraitErrors::doThrow));
-                return variable;
-            }
-        }.visit(methodDeclaration.getParameters(), parameters);
+        new ParameterCollector(cursor).visit(methodDeclaration.getParameters(), parameters);
         return unmodifiableList(parameters);
+    }
+}
+
+/**
+ * Collects the {@link Parameter}s declared under a callable. The parent cursor must be set to the
+ * callable so that each parameter resolves with the correct cursor path.
+ */
+class ParameterCollector extends JavaVisitor<List<Parameter>> {
+    ParameterCollector(Cursor callableCursor) {
+        setCursor(callableCursor);
+    }
+
+    @Override
+    public J visitVariable(J.VariableDeclarations.NamedVariable variable, List<Parameter> parameters) {
+        parameters.add(Parameter.viewOf(getCursor()).on(TraitErrors::doThrow));
+        return variable;
+    }
+}
+
+/**
+ * The implicit {@link Method} corresponding to a lambda expression. Modeled after CodeQL's
+ * {@code LambdaExpr.asMethod()}: the method corresponds to the single abstract method of the
+ * lambda's functional interface, the lambda's parameters are the parameters of this method,
+ * and the lambda body is the method body.
+ */
+@AllArgsConstructor
+class LambdaMethod extends Top.Base implements Method {
+    Cursor cursor;
+
+    J.Lambda lambda;
+
+    @Getter(lazy = true, onMethod_ = @Override)
+    private final List<Parameter> parameters = collectParameters(cursor, lambda);
+
+    @Getter(lazy = true)
+    private final Option<JavaType.Method> sam = findSam(lambda);
+
+    @Override
+    public String getName() {
+        // Fall back to a synthetic name (cf. "<clinit>"/"<obinit>") when the SAM is unresolved.
+        return getSam().map(JavaType.Method::getName).orSome("<lambda>");
+    }
+
+    @Override
+    public Option<JavaType> getReturnType() {
+        return getSam().map(JavaType.Method::getReturnType);
+    }
+
+    @Override
+    public Option<JavaType.Method> getMethodType() {
+        return getSam();
+    }
+
+    @Override
+    public UUID getId() {
+        return lambda.getId();
+    }
+
+    private static List<Parameter> collectParameters(Cursor cursor, J.Lambda lambda) {
+        assert cursor.getValue() == lambda;
+        List<Parameter> parameters = new ArrayList<>(lambda.getParameters().getParameters().size());
+        // Visit the Lambda.Parameters wrapper (not its inner list) so each parameter's cursor path
+        // is NamedVariable -> VariableDeclarations -> Lambda.Parameters -> Lambda, matching the LST.
+        new ParameterCollector(cursor).visit(lambda.getParameters(), parameters);
+        return unmodifiableList(parameters);
+    }
+
+    /**
+     * Resolves the single abstract method (SAM) of the lambda's functional interface type.
+     * Returns {@link Option#none()} when the type information is missing or the SAM cannot be
+     * unambiguously determined, allowing callers to fall back gracefully.
+     */
+    private static Option<JavaType.Method> findSam(J.Lambda lambda) {
+        JavaType type = lambda.getType();
+        if (!(type instanceof JavaType.FullyQualified)) {
+            return Option.none();
+        }
+        int arity = 0;
+        for (J parameter : lambda.getParameters().getParameters()) {
+            if (!(parameter instanceof J.Empty)) {
+                arity++;
+            }
+        }
+        JavaType.Method found = null;
+        for (JavaType.Method method : ((JavaType.FullyQualified) type).getMethods()) {
+            // The SAM is neither static nor a default method, and matches the lambda's arity.
+            if (method.hasFlags(Flag.Static) || method.hasFlags(Flag.Default)) {
+                continue;
+            }
+            if (method.getParameterTypes().size() != arity) {
+                continue;
+            }
+            if (found != null) {
+                // Ambiguous; fall back gracefully.
+                return Option.none();
+            }
+            found = method;
+        }
+        return Option.fromNull(found);
     }
 }

--- a/src/main/java/org/openrewrite/analysis/trait/variable/LocalVariableDecl.java
+++ b/src/main/java/org/openrewrite/analysis/trait/variable/LocalVariableDecl.java
@@ -125,9 +125,13 @@ class LocalVariableDeclBase extends Top.Base implements LocalVariableDecl {
             } else if (t instanceof J.Lambda) {
                 J.Lambda l = (J.Lambda) t;
                 assert previous != null : "previous should not be null";
-                if (l.getParameters().getParameters().contains(previous.<Statement>getValue())) {
+                if (l.getParameters() == previous.getValue()) {
+                    // This variable is a lambda parameter, which is modeled by Parameter rather
+                    // than LocalVariableDecl. The cursor reached the lambda via its Parameters node.
                     break;
                 }
+                // Otherwise this is a variable declared in the lambda body; the lambda's implicit
+                // method is its enclosing callable, so let Method.viewOf(lambda) resolve it below.
             }
             Validation<TraitErrors, Method> v = Method.viewOf(c);
             if (v.isSuccess()) {

--- a/src/main/java/org/openrewrite/analysis/trait/variable/Parameter.java
+++ b/src/main/java/org/openrewrite/analysis/trait/variable/Parameter.java
@@ -60,14 +60,20 @@ public interface Parameter extends LocalScopeVariable {
         public Validation<TraitErrors, Parameter> viewOf(Cursor c) {
             if (c.getValue() instanceof J.VariableDeclarations.NamedVariable) {
                 Cursor variableDeclarationsCursor = c.getParentTreeCursor();
-                Cursor methodDeclarationCursor = variableDeclarationsCursor.getParentTreeCursor();
-                return Method.viewOf(methodDeclarationCursor).map(callable -> new ParameterBase(
+                Cursor maybeCallableCursor = variableDeclarationsCursor.getParentTreeCursor();
+                // A lambda parameter is declared on the lambda's implicit method (its single
+                // abstract method), not on the lambda itself. The cursor path for such a parameter
+                // is NamedVariable -> VariableDeclarations -> J.Lambda.Parameters -> J.Lambda.
+                if (maybeCallableCursor.getValue() instanceof J.Lambda.Parameters) {
+                    maybeCallableCursor = maybeCallableCursor.getParentTreeCursor();
+                }
+                Cursor callableCursor = maybeCallableCursor;
+                return Method.viewOf(callableCursor).map(callable -> new ParameterBase(
                         c,
                         c.getValue(),
                         variableDeclarationsCursor.getValue(),
                         callable,
-                        methodDeclarationCursor,
-                        methodDeclarationCursor.getValue()
+                        callableCursor
                 ));
             }
             return TraitErrors.invalidTraitCreationType(Parameter.class, c, J.VariableDeclarations.NamedVariable.class);
@@ -89,8 +95,8 @@ class ParameterBase extends Top.Base implements Parameter {
     @Getter(onMethod_ =@Override)
     Method callable;
 
-    Cursor methodDeclarationCursor;
-    J.MethodDeclaration methodDeclaration;
+    /** The cursor of the enclosing callable, either a {@link J.MethodDeclaration} or a {@link J.Lambda}. */
+    Cursor callableCursor;
 
     @Override
     public UUID getId() {
@@ -110,7 +116,8 @@ class ParameterBase extends Top.Base implements Parameter {
     @Override
     public boolean isVarArgs() {
         if (this.namedVariable.getVariableType() == null) {
-            throw new IllegalStateException("Variable type is null for " + this.namedVariable);
+            // Lambda parameters may have no resolved variable type; they can never be varargs.
+            return false;
         }
         return this.namedVariable.getVariableType().hasFlags(Flag.Varargs);
     }
@@ -122,22 +129,36 @@ class ParameterBase extends Top.Base implements Parameter {
 
     @Override
     public Collection<VarAccess> getVarAccesses() {
-        if (methodDeclaration.getBody() == null) {
-            return emptySet();
-        }
-        return VarAccess.findAllInScope(new Cursor(methodDeclarationCursor, methodDeclaration.getBody()), this);
+        return bodyScope()
+                .map(scope -> VarAccess.findAllInScope(scope, this))
+                .orSome(emptySet());
     }
 
     @Override
     public Collection<Expr> getAssignedValues() {
-        if (methodDeclaration.getBody() == null) {
-            return emptySet();
-        }
-        return VariableUtil.findAssignedValues(new Cursor(methodDeclarationCursor, methodDeclaration.getBody()), this);
+        return bodyScope()
+                .map(scope -> VariableUtil.findAssignedValues(scope, this))
+                .orSome(emptySet());
     }
 
     @Override
     public Collection<Flag> getFlags() {
         return FlagUtil.fromModifiers(variableDeclarations.getModifiers());
+    }
+
+    /**
+     * The cursor pointing at the body in which this parameter is in scope: a method body or a
+     * lambda body. Empty for abstract methods, which have no body.
+     */
+    private Option<Cursor> bodyScope() {
+        Object callableTree = callableCursor.getValue();
+        if (callableTree instanceof J.MethodDeclaration) {
+            J.Block body = ((J.MethodDeclaration) callableTree).getBody();
+            return body == null ? Option.none() : Option.some(new Cursor(callableCursor, body));
+        }
+        if (callableTree instanceof J.Lambda) {
+            return Option.some(new Cursor(callableCursor, ((J.Lambda) callableTree).getBody()));
+        }
+        return Option.none();
     }
 }

--- a/src/test/java/org/openrewrite/analysis/dataflow/ParameterDataflowTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/ParameterDataflowTest.java
@@ -66,6 +66,126 @@ class ParameterDataflowTest implements RewriteTest {
     }
 
     @Test
+    void dataflowFromLambdaParameterExpressionBody() {
+        rewriteRun(
+          java(
+            """
+              interface Fun {
+                  String message(String source);
+              }
+
+              class Test {
+                  void test() {
+                      Fun foobar = (source) -> source;
+                  }
+              }
+              """,
+            """
+              interface Fun {
+                  String message(String source);
+              }
+
+              class Test {
+                  void test() {
+                      Fun foobar = (/*~~>*/source) -> /*~~>*/source;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dataflowFromLambdaParameterBlockBody() {
+        rewriteRun(
+          java(
+            """
+              interface Fun {
+                  String message(String source);
+              }
+
+              class Test {
+                  void test() {
+                      Fun foobar = (source) -> {
+                          return source;
+                      };
+                  }
+              }
+              """,
+            """
+              interface Fun {
+                  String message(String source);
+              }
+
+              class Test {
+                  void test() {
+                      Fun foobar = (/*~~>*/source) -> {
+                          return /*~~>*/source;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dataflowFromLambdaParameterIntoMethodCall() {
+        rewriteRun(
+          java(
+            """
+              import java.util.function.Function;
+
+              class Test {
+                  void test() {
+                      Function<String, String> f = (source) -> source.trim();
+                  }
+              }
+              """,
+            """
+              import java.util.function.Function;
+
+              class Test {
+                  void test() {
+                      Function<String, String> f = (/*~~>*/source) -> /*~~>*//*~~>*/source.trim();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dataflowFromTypedLambdaParameter() {
+        rewriteRun(
+          java(
+            """
+              interface Fun {
+                  String message(String s);
+              }
+
+              class Test {
+                  void test() {
+                      Fun foobar = (String source) -> source;
+                  }
+              }
+              """,
+            """
+              interface Fun {
+                  String message(String s);
+              }
+
+              class Test {
+                  void test() {
+                      Fun foobar = (String /*~~>*/source) -> /*~~>*/source;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void dataflowFromSourceArgumentToExpressions() {
         rewriteRun(
           java(

--- a/src/test/java/org/openrewrite/analysis/trait/expr/LambdaExprTest.java
+++ b/src/test/java/org/openrewrite/analysis/trait/expr/LambdaExprTest.java
@@ -18,12 +18,14 @@ package org.openrewrite.analysis.trait.expr;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.analysis.trait.member.Method;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
@@ -134,6 +136,94 @@ class LambdaExprTest implements RewriteTest {
                               return e;
                           }
                       });
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void asMethodResolvesFunctionalInterfaceMethod() {
+        // LambdaExpr.asMethod() models the lambda's implicit method as the single abstract method
+        // of its functional interface (here Function.apply), whose parameters are the lambda's.
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<ExecutionContext>() {
+              @Override
+              public J preVisit(J tree, ExecutionContext ctx) {
+                  return LambdaExpr.viewOf(getCursor()).map(lambda -> {
+                      Method method = lambda.asMethod();
+                      assertThat(method.getName()).as("SAM name").isEqualTo("apply");
+                      assertThat(method.getParameters()).singleElement().satisfies(p -> {
+                          assertThat(p.getName()).isEqualTo("s");
+                          assertThat(p.getPosition()).isZero();
+                          assertThat(p.getCallable()).isEqualTo(method);
+                      });
+                      return (J) SearchResult.found(tree);
+                  }).orSuccess(tree);
+              }
+          })).cycles(1).expectedCyclesThatMakeChanges(1),
+          java(
+            """
+              import java.util.function.Function;
+
+              class Test {
+                  void test() {
+                      Function<String, String> f = s -> s;
+                  }
+              }
+              """,
+            """
+              import java.util.function.Function;
+
+              class Test {
+                  void test() {
+                      Function<String, String> f = /*~~>*/s -> s;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void asMethodResolvesMultiParameterFunctionalInterface() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<ExecutionContext>() {
+              @Override
+              public J preVisit(J tree, ExecutionContext ctx) {
+                  return LambdaExpr.viewOf(getCursor()).map(lambda -> {
+                      Method method = lambda.asMethod();
+                      assertThat(method.getName()).as("SAM name").isEqualTo("combine");
+                      assertThat(method.getParameters()).hasSize(2);
+                      assertThat(method.getParameters().get(0).getName()).isEqualTo("a");
+                      assertThat(method.getParameters().get(0).getPosition()).isZero();
+                      assertThat(method.getParameters().get(1).getName()).isEqualTo("b");
+                      assertThat(method.getParameters().get(1).getPosition()).isEqualTo(1);
+                      return (J) SearchResult.found(tree);
+                  }).orSuccess(tree);
+              }
+          })).cycles(1).expectedCyclesThatMakeChanges(1),
+          java(
+            """
+              interface Two {
+                  String combine(String a, String b);
+              }
+
+              class Test {
+                  void test() {
+                      Two t = (a, b) -> a + b;
+                  }
+              }
+              """,
+            """
+              interface Two {
+                  String combine(String a, String b);
+              }
+
+              class Test {
+                  void test() {
+                      Two t = /*~~>*/(a, b) -> a + b;
                   }
               }
               """

--- a/src/test/java/org/openrewrite/analysis/trait/variable/LambdaTest.java
+++ b/src/test/java/org/openrewrite/analysis/trait/variable/LambdaTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.analysis.trait.variable;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
@@ -86,7 +85,6 @@ class LambdaTest implements RewriteTest {
         );
     }
 
-    @Disabled("https://github.com/openrewrite/rewrite-analysis/issues/31")
     @Test
     void lambdaNewInstance() {
         //language=java
@@ -126,7 +124,6 @@ class LambdaTest implements RewriteTest {
         );
     }
 
-    @Disabled("https://github.com/openrewrite/rewrite-analysis/issues/31")
     @Test
     void lambdaReturn() {
         //language=java

--- a/src/test/java/org/openrewrite/analysis/trait/variable/ParameterTest.java
+++ b/src/test/java/org/openrewrite/analysis/trait/variable/ParameterTest.java
@@ -75,6 +75,48 @@ class ParameterTest implements RewriteTest {
     }
 
     @Test
+    void lambdaParameter() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(visitVariable((variable, cursor) -> {
+                if (!"p".equals(variable.getSimpleName())) {
+                    return variable;
+                }
+                Parameter param = Parameter.viewOf(cursor).on(TraitErrors::doThrow);
+                assertThat(param.getPosition()).as("Lambda parameter position is incorrect").isZero();
+                assertThat(param.isVarArgs()).as("Lambda parameter isVarArgs is incorrect").isFalse();
+                assertThat(param.getName()).as("Lambda parameter name is incorrect").isEqualTo("p");
+                assertThat(param.getCallable().getName()).as("Lambda callable (SAM) name is incorrect").isEqualTo("message");
+                return SearchResult.found(variable);
+            }
+          ))),
+          java(
+            """
+              interface Fun {
+                  String message(String s);
+              }
+
+              class Test {
+                  void test() {
+                      Fun foobar = (p) -> p;
+                  }
+              }
+              """,
+            """
+              interface Fun {
+                  String message(String s);
+              }
+
+              class Test {
+                  void test() {
+                      Fun foobar = (/*~~>*/p) -> p;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void variableVisitVarargs() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(visitVariable((variable, cursor) -> {


### PR DESCRIPTION
## Motivation

- The analysis trait model is a direct port of CodeQL's Java library, but lambda parameters were never modeled (#38): `Parameter.Factory` only recognized parameters declared on a `J.MethodDeclaration`. Because `DataFlowNode` treats a variable as a flow source only when `Parameter.viewOf` succeeds, a lambda parameter could never participate in data flow. A related gap (#31) meant local variables declared inside a lambda body failed to resolve their enclosing callable (throwing when the lambda had no enclosing method, e.g. in a field initializer).

CodeQL models a lambda not as a `Callable` itself, but via `FunctionalExpr.asMethod()`, which returns the implicit method implementing the functional interface's single abstract method (SAM); the lambda's parameters are that method's parameters. This change brings the same model to the trait hierarchy.

## Examples

```java
interface Fun {
    String message(String source);
}

class Test {
    void test() {
        // `source` is now a first-class Parameter and a data flow source;
        // flow is tracked into the lambda body.
        Fun foobar = (source) -> source;
    }
}
```

```java
// LambdaExpr now exposes its implicit method, à la CodeQL.
LambdaExpr lambda = ...;
Method m = lambda.asMethod();   // the SAM, e.g. Function.apply
m.getName();                    // "apply"
m.getParameters();              // the lambda's parameters
```

## Summary

- Added `FunctionalExpr.asMethod()` and implemented it for `LambdaExpr`.
- Added a lambda-backed `Method` (`Method.viewOf` now accepts `J.Lambda`) whose parameters are the lambda's and whose name/return/method type are resolved from the functional interface's SAM, with graceful fallback when it can't be resolved.
- `Parameter.Factory` now recognizes lambda parameters; `getVarAccesses()`/`getAssignedValues()` are scoped to the lambda body.
- Fixed `LocalVariableDecl.findNearestParentCallable` so variables declared in a lambda body resolve to the lambda's implicit method (#31).
- `ForwardFlow` begins flow inside the lambda body when the source is a lambda parameter.

Higher-order *dispatch* (connecting a functional-interface call such as `stream.map(x -> …)` to the lambda body) is intentionally out of scope and remains a follow-up.

## Test plan

- [x] `ParameterTest#lambdaParameter` — a lambda parameter resolves to a `Parameter` with correct position, name, and callable (SAM) name
- [x] `LambdaExprTest#asMethodResolvesFunctionalInterfaceMethod` / `#asMethodResolvesMultiParameterFunctionalInterface` — `asMethod()` SAM resolution and parameter modeling
- [x] `ParameterDataflowTest` — flow from a lambda parameter through expression bodies, block bodies, into method calls, and with typed parameters
- [x] Re-enabled the previously `@Disabled` #31 tests in `LambdaTest` (`lambdaNewInstance`, `lambdaReturn`)
- [x] Full module test suite green (372 tests, 0 failures)
