### PR TITLE
Support higher-order ("lambda call") data flow through lambda arguments

### DIFF
--- a/src/main/java/org/openrewrite/analysis/dataflow/CallbackFlowModel.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/CallbackFlowModel.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.dataflow;
+
+import lombok.Value;
+import org.openrewrite.analysis.InvocationMatcher;
+
+/**
+ * A higher-order ("lambda call") flow model derived from a CodeQL-style summary whose access path
+ * references a functional argument's parameter or return value. Mirrors CodeQL's
+ * {@code lambdaCall}/{@code lambdaCreation}: when a method is invoked with a lambda (or anonymous
+ * functional implementation) argument, data can flow into that lambda's parameter or out of its
+ * return value.
+ * <ul>
+ *     <li>{@link Direction#INTO}: data flows from the {@link #other} position of the call into
+ *     parameter {@link #parameter} of the lambda passed as argument {@link #callbackArgument}
+ *     (e.g. {@code Iterable.forEach}: {@code Argument[-1] -> Argument[0].Parameter[0]}).</li>
+ *     <li>{@link Direction#OUT}: data flows from the return value of the lambda passed as argument
+ *     {@link #callbackArgument} to the {@link #other} position of the call
+ *     (e.g. {@code Map.computeIfAbsent}: {@code Argument[1].ReturnValue -> ReturnValue}).</li>
+ * </ul>
+ */
+@Value
+public class CallbackFlowModel {
+    public enum Direction {
+        INTO,
+        OUT
+    }
+
+    InvocationMatcher matcher;
+
+    Direction direction;
+
+    /** The argument index of the call holding the lambda. {@code -1} denotes the qualifier. */
+    int callbackArgument;
+
+    /** For {@link Direction#INTO}, the lambda parameter index that receives the data. */
+    int parameter;
+
+    /** The non-callback side of the flow (the source for {@code INTO}, the destination for {@code OUT}). */
+    Position other;
+
+    /** A position at a call site: the qualifier, an argument, or the return value. */
+    @Value
+    public static class Position {
+        public enum Kind {
+            QUALIFIER,
+            ARGUMENT,
+            RETURN_VALUE
+        }
+
+        Kind kind;
+
+        /** The argument index when {@link #kind} is {@link Kind#ARGUMENT}; otherwise unused. */
+        int argument;
+
+        public static Position qualifier() {
+            return new Position(Kind.QUALIFIER, -1);
+        }
+
+        public static Position returnValue() {
+            return new Position(Kind.RETURN_VALUE, -1);
+        }
+
+        public static Position argument(int index) {
+            return index == -1 ? qualifier() : new Position(Kind.ARGUMENT, index);
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/analysis/dataflow/DataFlowSpec.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/DataFlowSpec.java
@@ -18,6 +18,8 @@ package org.openrewrite.analysis.dataflow;
 import org.openrewrite.Incubating;
 import org.openrewrite.analysis.controlflow.Guard;
 
+import java.util.List;
+
 @Incubating(since = "7.24.0")
 public abstract class DataFlowSpec {
     /**
@@ -68,6 +70,15 @@ public abstract class DataFlowSpec {
 
     public boolean isBarrierGuard(Guard guard, boolean branch) {
         return false;
+    }
+
+    /**
+     * The higher-order ("lambda call") flow models that apply at the given call node. Used by the
+     * flow engine to route data into a lambda argument's parameter or out of its return value.
+     * Callers must still confirm a given model's {@link CallbackFlowModel#getMatcher()} matches the call.
+     */
+    public List<CallbackFlowModel> callbackFlowModels(DataFlowNode callNode) {
+        return ExternalFlowModels.instance().valueCallbackFlowModels(callNode.getCursor());
     }
 
     /**

--- a/src/main/java/org/openrewrite/analysis/dataflow/ExternalFlowModels.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/ExternalFlowModels.java
@@ -19,6 +19,7 @@ import lombok.*;
 import org.openrewrite.Cursor;
 import org.openrewrite.Incubating;
 import org.openrewrite.analysis.InvocationMatcher;
+import org.openrewrite.analysis.dataflow.internal.csv.AccessPath;
 import org.openrewrite.analysis.dataflow.internal.csv.CsvLoader;
 import org.openrewrite.analysis.dataflow.internal.csv.GenericExternalModel;
 import org.openrewrite.analysis.dataflow.internal.csv.Mergeable;
@@ -103,10 +104,27 @@ final class ExternalFlowModels {
         return false;
     }
 
+    /**
+     * The higher-order ("lambda call") value-flow models applicable to the compilation unit
+     * enclosing {@code cursor}. Callers should filter these to the ones whose matcher matches a
+     * particular call.
+     */
+    List<CallbackFlowModel> valueCallbackFlowModels(Cursor cursor) {
+        return getOrComputeOptimizedFlowModels(cursor).getValueCallbacks();
+    }
+
+    List<CallbackFlowModel> taintCallbackFlowModels(Cursor cursor) {
+        return getOrComputeOptimizedFlowModels(cursor).getTaintCallbacks();
+    }
+
     @AllArgsConstructor
     static final class OptimizedFlowModels {
         private final Map<AdditionalFlowStepPredicate, Set<FlowModel>> value;
         private final Map<AdditionalFlowStepPredicate, Set<FlowModel>> taint;
+        @Getter
+        private final List<CallbackFlowModel> valueCallbacks;
+        @Getter
+        private final List<CallbackFlowModel> taintCallbacks;
 
         Set<AdditionalFlowStepPredicate> getValuePredicates() {
             return value.keySet();
@@ -279,8 +297,70 @@ final class ExternalFlowModels {
             Optimizer optimizer = new Optimizer();
             return new OptimizedFlowModels(
                     optimizer.optimize(flowModels.value),
-                    optimizer.optimize(flowModels.taint)
+                    optimizer.optimize(flowModels.taint),
+                    buildCallbackModels(flowModels.value),
+                    buildCallbackModels(flowModels.taint)
             );
+        }
+
+        /**
+         * Builds the higher-order ("lambda call") models from rows whose access path references a
+         * functional argument's parameter or return value. Content components have already been
+         * collapsed by {@link AccessPath}. Rows where <em>both</em> sides are callbacks, or where
+         * either side is unparseable, are skipped.
+         */
+        private static List<CallbackFlowModel> buildCallbackModels(Collection<FlowModel> models) {
+            List<CallbackFlowModel> callbacks = new ArrayList<>();
+            for (FlowModel model : models) {
+                Optional<AccessPath> maybeIn = AccessPath.parse(model.input);
+                Optional<AccessPath> maybeOut = AccessPath.parse(model.output);
+                if (!maybeIn.isPresent() || !maybeOut.isPresent()) {
+                    continue;
+                }
+                AccessPath in = maybeIn.get();
+                AccessPath out = maybeOut.get();
+                InvocationMatcher matcher = InvocationMatcher.from(java.util.Collections.singletonList(model));
+                if (out.getCallbackKind() == AccessPath.CallbackKind.PARAMETER &&
+                    !in.isCallback() && in.getRoot() == AccessPath.Root.ARGUMENT) {
+                    // INTO: in (an argument/qualifier) flows to Argument[i].Parameter[j].
+                    forEachIndex(out.getRootRange(), i ->
+                            forEachIndex(out.getCallbackRange(), j ->
+                                    forEachIndex(in.getRootRange(), k ->
+                                            callbacks.add(new CallbackFlowModel(
+                                                    matcher,
+                                                    CallbackFlowModel.Direction.INTO,
+                                                    i,
+                                                    j,
+                                                    CallbackFlowModel.Position.argument(k))))));
+                } else if (in.getCallbackKind() == AccessPath.CallbackKind.RETURN_VALUE && !out.isCallback()) {
+                    // OUT: Argument[i].ReturnValue flows to out (the return value or an argument/qualifier).
+                    forEachIndex(in.getRootRange(), i -> {
+                        if (out.getRoot() == AccessPath.Root.RETURN_VALUE) {
+                            callbacks.add(new CallbackFlowModel(
+                                    matcher,
+                                    CallbackFlowModel.Direction.OUT,
+                                    i,
+                                    -1,
+                                    CallbackFlowModel.Position.returnValue()));
+                        } else {
+                            forEachIndex(out.getRootRange(), k ->
+                                    callbacks.add(new CallbackFlowModel(
+                                            matcher,
+                                            CallbackFlowModel.Direction.OUT,
+                                            i,
+                                            -1,
+                                            CallbackFlowModel.Position.argument(k))));
+                        }
+                    });
+                }
+            }
+            return callbacks;
+        }
+
+        private static void forEachIndex(GenericExternalModel.ArgumentRange range, java.util.function.IntConsumer consumer) {
+            for (int i = range.getStart(); i <= range.getEnd(); i++) {
+                consumer.accept(i);
+            }
         }
     }
 

--- a/src/main/java/org/openrewrite/analysis/dataflow/TaintFlowSpec.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/TaintFlowSpec.java
@@ -18,8 +18,18 @@ package org.openrewrite.analysis.dataflow;
 import org.openrewrite.Incubating;
 import org.openrewrite.analysis.controlflow.Guard;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Incubating(since = "7.25.0")
 public abstract class TaintFlowSpec extends DataFlowSpec {
+
+    @Override
+    public final List<CallbackFlowModel> callbackFlowModels(DataFlowNode callNode) {
+        List<CallbackFlowModel> models = new ArrayList<>(super.callbackFlowModels(callNode));
+        models.addAll(ExternalFlowModels.instance().taintCallbackFlowModels(callNode.getCursor()));
+        return models;
+    }
 
     @Override
     public final boolean isAdditionalFlowStep(

--- a/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
@@ -677,14 +677,11 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                     otherTargets.add(target);
                 }
             }
-            // Continue the flow from the call's output node in the enclosing scope (the source may sit
-            // inside a lambda block body, which `findAllFlows` would not otherwise leave).
-            if (returnValueTarget != null) {
-                findAllFlows(currentFlow.addEdge(returnValueTarget), spec);
-                return;
-            }
-            if (!otherTargets.isEmpty()) {
-                for (DataFlowNode target : otherTargets) {
+            // Continue the flow from the call's output node(s) in the enclosing scope (the source may
+            // sit inside a lambda block body, which `findAllFlows` would not otherwise leave).
+            List<DataFlowNode> targets = returnValueTarget != null ? singletonList(returnValueTarget) : otherTargets;
+            if (!targets.isEmpty()) {
+                for (DataFlowNode target : targets) {
                     findAllFlows(currentFlow.addEdge(target), spec);
                 }
                 return;

--- a/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
@@ -17,11 +17,15 @@ package org.openrewrite.analysis.dataflow.analysis;
 
 import fj.data.Option;
 import lombok.AllArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.Incubating;
 import org.openrewrite.Tree;
+import org.openrewrite.analysis.InvocationMatcher;
+import org.openrewrite.analysis.dataflow.CallbackFlowModel;
 import org.openrewrite.analysis.dataflow.DataFlowNode;
 import org.openrewrite.analysis.dataflow.DataFlowSpec;
+import org.openrewrite.analysis.trait.expr.Call;
 import org.openrewrite.analysis.trait.expr.VarAccess;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
@@ -497,6 +501,13 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                             }
                         }
                     }
+
+                    // Into-callback ("lambda call"): route flow from the select or an argument into a
+                    // parameter of a lambda passed as another argument, per any matching model (e.g.
+                    // Iterable.forEach passes the receiver's elements to the consumer's parameter).
+                    if (tryIntoCallbackFlow(nextFlowGraph, parentCursor, previousCursor, spec)) {
+                        break;
+                    }
                 } else if (parentCursor.getValue() instanceof J.NewClass) {
                     // The parent is a J.NewClass, `previousCursor` must be an argument
                     J.NewClass constructorInvocation = parentCursor.getValue();
@@ -574,9 +585,12 @@ public class ForwardFlow extends JavaVisitor<Integer> {
 
             if (ancestor instanceof J.Binary) {
                 break;
-            } else if (ancestor instanceof J.MethodInvocation) {
-                break;
-            } else if (ancestor instanceof J.NewClass) {
+            } else if (ancestor instanceof J.MethodInvocation || ancestor instanceof J.NewClass) {
+                // Out-of-callback ("lambda call"): if the current flow node is the result of a lambda
+                // passed as an argument of this call, route flow to the call's output node per any
+                // matching out-of-callback model (e.g. Map.computeIfAbsent maps the mapping function's
+                // return value to the call result).
+                tryOutOfCallbackFlow(nextFlowGraph, ancestorCursor, spec);
                 break;
             } else if (ancestor instanceof J.Assignment ||
                        ancestor instanceof J.AssignmentOperation ||
@@ -599,5 +613,187 @@ public class ForwardFlow extends JavaVisitor<Integer> {
             }
         }
         return new VariableNameToFlowGraph(identifierToFlow, ancestorCursor, cursorPath);
+    }
+
+    /**
+     * Routes flow out of a lambda's return value to a call's output node, per any matching
+     * out-of-callback model, then continues the flow from that output node in the enclosing scope.
+     */
+    private static void tryOutOfCallbackFlow(FlowGraph currentFlow, Cursor callCursor, DataFlowSpec spec) {
+        Object call = callCursor.getValue();
+        List<Expression> arguments;
+        Expression select = null;
+        if (call instanceof J.MethodInvocation) {
+            arguments = ((J.MethodInvocation) call).getArguments();
+            select = ((J.MethodInvocation) call).getSelect();
+        } else if (call instanceof J.NewClass) {
+            arguments = ((J.NewClass) call).getArguments();
+            if (arguments == null) {
+                return;
+            }
+        } else {
+            return;
+        }
+        List<CallbackFlowModel> models = spec.callbackFlowModels(currentFlow.getNode());
+        if (models.isEmpty()) {
+            return;
+        }
+        Cursor currentCursor = currentFlow.getNode().getCursor();
+        for (int i = 0; i < arguments.size(); i++) {
+            Expression unwrapped = arguments.get(i).unwrap();
+            if (!(unwrapped instanceof J.Lambda)) {
+                continue;
+            }
+            J.Lambda lambda = (J.Lambda) unwrapped;
+            if (!isAncestor(lambda, currentCursor) || !isLambdaResult(currentCursor, lambda)) {
+                continue;
+            }
+            for (CallbackFlowModel model : models) {
+                if (model.getDirection() != CallbackFlowModel.Direction.OUT || model.getCallbackArgument() != i) {
+                    continue;
+                }
+                if (!callMatches(callCursor, model.getMatcher())) {
+                    continue;
+                }
+                DataFlowNode target = resolveCallbackOutput(callCursor, select, arguments, model.getOther());
+                if (target != null) {
+                    // Continue the flow from the call's output node in the enclosing scope (the source
+                    // may sit inside a lambda block body, which `findAllFlows` would not otherwise leave).
+                    findAllFlows(currentFlow.addEdge(target), spec);
+                    return;
+                }
+            }
+        }
+    }
+
+    private static @Nullable DataFlowNode resolveCallbackOutput(
+            Cursor callCursor,
+            @Nullable Expression select,
+            List<Expression> arguments,
+            CallbackFlowModel.Position position
+    ) {
+        switch (position.getKind()) {
+            case RETURN_VALUE:
+                return DataFlowNode.of(callCursor).toNull();
+            case QUALIFIER:
+                if (select == null) {
+                    return null;
+                }
+                return DataFlowNode.of(new Cursor(callCursor, select)).toNull();
+            case ARGUMENT:
+                int k = position.getArgument();
+                if (k < 0 || k >= arguments.size()) {
+                    return null;
+                }
+                return DataFlowNode.of(new Cursor(callCursor, arguments.get(k))).toNull();
+            default:
+                return null;
+        }
+    }
+
+    private static boolean callMatches(Cursor callCursor, InvocationMatcher matcher) {
+        return Call.viewOf(callCursor).map(c -> c.matches(matcher)).orSuccess(false);
+    }
+
+    /**
+     * Routes flow into a lambda argument's parameter, per any matching into-callback model. Seeds a
+     * sub-flow from the lambda parameter (reusing the lambda-parameter-source traversal) so flow
+     * continues through the lambda body. Returns {@code true} when at least one such edge was added.
+     */
+    private static boolean tryIntoCallbackFlow(FlowGraph currentFlow, Cursor callCursor, Cursor inputCursor, DataFlowSpec spec) {
+        if (!(callCursor.getValue() instanceof J.MethodInvocation)) {
+            return false;
+        }
+        J.MethodInvocation mi = callCursor.getValue();
+        List<CallbackFlowModel> models = spec.callbackFlowModels(currentFlow.getNode());
+        if (models.isEmpty()) {
+            return false;
+        }
+        Object input = inputCursor.getValue();
+        boolean added = false;
+        for (CallbackFlowModel model : models) {
+            if (model.getDirection() != CallbackFlowModel.Direction.INTO ||
+                !matchesInputPosition(model.getOther(), input, mi)) {
+                continue;
+            }
+            int i = model.getCallbackArgument();
+            if (i < 0 || i >= mi.getArguments().size()) {
+                continue;
+            }
+            Expression argExpr = mi.getArguments().get(i).unwrap();
+            if (!(argExpr instanceof J.Lambda) || !callMatches(callCursor, model.getMatcher())) {
+                continue;
+            }
+            Cursor paramCursor = lambdaParameterCursor(callCursor, (J.Lambda) argExpr, model.getParameter());
+            if (paramCursor == null) {
+                continue;
+            }
+            DataFlowNode paramNode = DataFlowNode.of(paramCursor).toNull();
+            if (paramNode == null) {
+                continue;
+            }
+            FlowGraph paramFlow = currentFlow.addEdge(paramNode);
+            findAllFlows(paramFlow, spec);
+            added = true;
+        }
+        return added;
+    }
+
+    private static boolean matchesInputPosition(CallbackFlowModel.Position position, Object input, J.MethodInvocation mi) {
+        switch (position.getKind()) {
+            case QUALIFIER:
+                return mi.getSelect() == input;
+            case ARGUMENT:
+                int k = position.getArgument();
+                return k >= 0 && k < mi.getArguments().size() && mi.getArguments().get(k) == input;
+            default:
+                return false;
+        }
+    }
+
+    private static @Nullable Cursor lambdaParameterCursor(Cursor callCursor, J.Lambda lambda, int parameterIndex) {
+        J.Lambda.Parameters parameters = lambda.getParameters();
+        List<J> parameterDeclarations = parameters.getParameters();
+        if (parameterIndex < 0 || parameterIndex >= parameterDeclarations.size()) {
+            return null;
+        }
+        J parameterDeclaration = parameterDeclarations.get(parameterIndex);
+        if (!(parameterDeclaration instanceof J.VariableDeclarations)) {
+            return null;
+        }
+        J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) parameterDeclaration;
+        if (variableDeclarations.getVariables().isEmpty()) {
+            return null;
+        }
+        Cursor lambdaCursor = new Cursor(callCursor, lambda);
+        Cursor parametersCursor = new Cursor(lambdaCursor, parameters);
+        Cursor variableDeclarationsCursor = new Cursor(parametersCursor, variableDeclarations);
+        return new Cursor(variableDeclarationsCursor, variableDeclarations.getVariables().get(0));
+    }
+
+    /** Holds if {@code maybeAncestor} appears on the cursor's path (i.e. encloses it). */
+    private static boolean isAncestor(J maybeAncestor, Cursor cursor) {
+        for (Iterator<Object> it = cursor.getPath(); it.hasNext(); ) {
+            if (it.next() == maybeAncestor) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Holds if the node at {@code nodeCursor} is (the expression of) the lambda's return value. */
+    private static boolean isLambdaResult(Cursor nodeCursor, J.Lambda lambda) {
+        J node = nodeCursor.getValue();
+        J body = lambda.getBody();
+        if (!(body instanceof J.Block)) {
+            return body instanceof Expression && Expression.unwrap((Expression) body) == node;
+        }
+        J.Return aReturn = nodeCursor.firstEnclosing(J.Return.class);
+        if (aReturn == null || aReturn.getExpression() == null ||
+            Expression.unwrap(aReturn.getExpression()) != node) {
+            return false;
+        }
+        // The return must belong to this lambda, not a nested lambda or anonymous-class method.
+        return nodeCursor.firstEnclosing(J.Lambda.class) == lambda;
     }
 }

--- a/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
@@ -648,6 +648,18 @@ public class ForwardFlow extends JavaVisitor<Integer> {
             if (!isAncestor(lambda, currentCursor) || !isLambdaResult(currentCursor, lambda)) {
                 continue;
             }
+            // A single call/argument can match several OUT models. Map.computeIfAbsent, for instance,
+            // maps the mapping function's return value both to the call result (`Argument[1].ReturnValue
+            // -> ReturnValue`) and into the map's values (`Argument[1].ReturnValue -> Argument[-1].MapValue`,
+            // which this content-insensitive engine resolves to the whole `map` qualifier). Selecting one
+            // deterministically matters: the old code stopped at the first match, so the surviving flow
+            // depended on model iteration order, which is not stable across runs.
+            //
+            // Prefer the call result (the precise forward flow); fall back to the other resolved targets
+            // only when no ReturnValue model applies. Routing to both would also redundantly mark the
+            // qualifier that the result expression already encloses.
+            DataFlowNode returnValueTarget = null;
+            List<DataFlowNode> otherTargets = new ArrayList<>();
             for (CallbackFlowModel model : models) {
                 if (model.getDirection() != CallbackFlowModel.Direction.OUT || model.getCallbackArgument() != i) {
                     continue;
@@ -656,12 +668,26 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                     continue;
                 }
                 DataFlowNode target = resolveCallbackOutput(callCursor, select, arguments, model.getOther());
-                if (target != null) {
-                    // Continue the flow from the call's output node in the enclosing scope (the source
-                    // may sit inside a lambda block body, which `findAllFlows` would not otherwise leave).
-                    findAllFlows(currentFlow.addEdge(target), spec);
-                    return;
+                if (target == null) {
+                    continue;
                 }
+                if (model.getOther().getKind() == CallbackFlowModel.Position.Kind.RETURN_VALUE) {
+                    returnValueTarget = target;
+                } else {
+                    otherTargets.add(target);
+                }
+            }
+            // Continue the flow from the call's output node in the enclosing scope (the source may sit
+            // inside a lambda block body, which `findAllFlows` would not otherwise leave).
+            if (returnValueTarget != null) {
+                findAllFlows(currentFlow.addEdge(returnValueTarget), spec);
+                return;
+            }
+            if (!otherTargets.isEmpty()) {
+                for (DataFlowNode target : otherTargets) {
+                    findAllFlows(currentFlow.addEdge(target), spec);
+                }
+                return;
             }
         }
     }

--- a/src/main/java/org/openrewrite/analysis/dataflow/internal/csv/AccessPath.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/internal/csv/AccessPath.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.dataflow.internal.csv;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.analysis.dataflow.internal.csv.GenericExternalModel.ArgumentRange;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A structured representation of a CodeQL-style data-flow access path such as {@code Argument[0]},
+ * {@code Argument[-1].Element}, {@code Argument[0].Parameter[1]} or {@code Argument[1].ReturnValue}.
+ * <p>
+ * An access path is parsed into a {@link Root} (an argument position or the method return value) and
+ * an optional <em>callback</em> component describing flow into a functional argument's parameter
+ * ({@link CallbackKind#PARAMETER}) or out of a functional argument's return value
+ * ({@link CallbackKind#RETURN_VALUE}). This is what enables higher-order ("lambda call") flow.
+ * <p>
+ * Content components ({@code Element}, {@code ArrayElement}, {@code MapKey}, {@code MapValue},
+ * {@code Field[...]}, {@code SyntheticField[...]}) are <em>collapsed</em> onto their container: this
+ * analysis is not content/field sensitive, so {@code Argument[-1].Element} is treated as
+ * {@code Argument[-1]}. This is an over-approximation consistent with the engine's whole-value
+ * granularity.
+ */
+@Value
+public class AccessPath {
+    public enum Root {
+        ARGUMENT,
+        RETURN_VALUE
+    }
+
+    public enum CallbackKind {
+        NONE,
+        /** Flow into a functional argument's parameter, e.g. {@code Argument[0].Parameter[1]}. */
+        PARAMETER,
+        /** Flow out of a functional argument's return value, e.g. {@code Argument[1].ReturnValue}. */
+        RETURN_VALUE
+    }
+
+    Root root;
+
+    /** The argument range when {@link #root} is {@link Root#ARGUMENT}; otherwise {@code null}. */
+    @Nullable
+    ArgumentRange rootRange;
+
+    CallbackKind callbackKind;
+
+    /** The parameter range when {@link #callbackKind} is {@link CallbackKind#PARAMETER}; otherwise {@code null}. */
+    @Nullable
+    ArgumentRange callbackRange;
+
+    public boolean isCallback() {
+        return callbackKind != CallbackKind.NONE;
+    }
+
+    public static Optional<AccessPath> parse(String path) {
+        List<String> components = tokenize(path);
+        if (components.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String head = components.get(0);
+        Root root;
+        ArgumentRange rootRange = null;
+        if ("ReturnValue".equals(head)) {
+            root = Root.RETURN_VALUE;
+        } else if (head.startsWith("Argument[")) {
+            Optional<ArgumentRange> range = parseRange(head, "Argument");
+            if (!range.isPresent()) {
+                return Optional.empty();
+            }
+            root = Root.ARGUMENT;
+            rootRange = range.get();
+        } else {
+            return Optional.empty();
+        }
+
+        CallbackKind callbackKind = CallbackKind.NONE;
+        ArgumentRange callbackRange = null;
+        for (int i = 1; i < components.size() && callbackKind == CallbackKind.NONE; i++) {
+            String component = components.get(i);
+            if (isContent(component)) {
+                // Collapsed onto the container; ignore.
+                continue;
+            }
+            if (root == Root.ARGUMENT && "ReturnValue".equals(component)) {
+                callbackKind = CallbackKind.RETURN_VALUE;
+            } else if (root == Root.ARGUMENT && component.startsWith("Parameter[")) {
+                Optional<ArgumentRange> range = parseRange(component, "Parameter");
+                if (!range.isPresent()) {
+                    return Optional.empty();
+                }
+                callbackKind = CallbackKind.PARAMETER;
+                callbackRange = range.get();
+            } else {
+                // An access-path component we don't model; treat the whole path as unparseable so it
+                // is conservatively ignored rather than silently misinterpreted.
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(new AccessPath(root, rootRange, callbackKind, callbackRange));
+    }
+
+    private static boolean isContent(String component) {
+        return "Element".equals(component) ||
+               "ArrayElement".equals(component) ||
+               "MapKey".equals(component) ||
+               "MapValue".equals(component) ||
+               component.startsWith("Field[") ||
+               component.startsWith("SyntheticField[");
+    }
+
+    private static Optional<ArgumentRange> parseRange(String component, String prefix) {
+        // component looks like "<prefix>[x]" or "<prefix>[x..y]"
+        if (!component.startsWith(prefix + "[") || !component.endsWith("]")) {
+            return Optional.empty();
+        }
+        return GenericExternalModel.computeArgumentRange("Argument" + component.substring(prefix.length()));
+    }
+
+    /** Splits an access path on top-level {@code .} separators, respecting {@code [...]} brackets. */
+    private static List<String> tokenize(String path) {
+        List<String> components = new ArrayList<>();
+        if (path.isEmpty()) {
+            return components;
+        }
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '[') {
+                depth++;
+            } else if (c == ']') {
+                depth--;
+            } else if (c == '.' && depth == 0) {
+                components.add(path.substring(start, i));
+                start = i + 1;
+            }
+        }
+        components.add(path.substring(start));
+        return components;
+    }
+}

--- a/src/main/java/org/openrewrite/analysis/trait/variable/Parameter.java
+++ b/src/main/java/org/openrewrite/analysis/trait/variable/Parameter.java
@@ -110,6 +110,16 @@ class ParameterBase extends Top.Base implements Parameter {
 
     @Override
     public int getPosition() {
+        // Compute the index directly from the LST rather than via callable.getParameters().indexOf(this).
+        // The latter rebuilds the callable's full Parameter list on every call and, for a lambda, mints a
+        // fresh Method per parameter (whose lazy caches are never shared), making positioning O(n^2).
+        Object callableTree = callableCursor.getValue();
+        if (callableTree instanceof J.MethodDeclaration) {
+            return ((J.MethodDeclaration) callableTree).getParameters().indexOf(variableDeclarations);
+        }
+        if (callableTree instanceof J.Lambda) {
+            return ((J.Lambda) callableTree).getParameters().getParameters().indexOf(variableDeclarations);
+        }
         return callable.getParameters().indexOf(this);
     }
 

--- a/src/main/java/org/openrewrite/analysis/util/CursorUtil.java
+++ b/src/main/java/org/openrewrite/analysis/util/CursorUtil.java
@@ -33,13 +33,25 @@ public class CursorUtil {
     public static Option<Cursor> findCallableBlockCursor(Cursor start) {
         Iterator<Cursor> cursorPath = start.getPathAsCursors();
         Cursor methodDeclarationBlockCursor = null;
+        Cursor lambdaBodyBlockCursor = null;
         while (cursorPath.hasNext()) {
             Cursor nextCursor = cursorPath.next();
             Object next = nextCursor.getValue();
             if (next instanceof J.Block) {
                 methodDeclarationBlockCursor = nextCursor;
-                if (J.Block.isStaticOrInitBlock(nextCursor) || nextCursor.getParentTreeCursor().getValue() instanceof J.Lambda) {
+                if (J.Block.isStaticOrInitBlock(nextCursor)) {
                     return Option.some(nextCursor);
+                }
+                if (nextCursor.getParentTreeCursor().getValue() instanceof J.Lambda) {
+                    // A block-body lambda forms its own control-flow region. Remember the innermost
+                    // such block as a fallback, but keep walking up so a source inside the lambda is
+                    // scoped to its enclosing method body — this lets data flow escape the lambda's
+                    // `return` to the enclosing call result (higher-order "OUT" flow). When the lambda
+                    // has no enclosing method (e.g. a field-initializer lambda), there is no method
+                    // body to widen to, so we fall back to this block below.
+                    if (lambdaBodyBlockCursor == null) {
+                        lambdaBodyBlockCursor = nextCursor;
+                    }
                 }
             } else if (next instanceof J.MethodDeclaration) {
                 if (methodDeclarationBlockCursor == null && ((J.MethodDeclaration) next).getBody() != null) {
@@ -48,7 +60,7 @@ public class CursorUtil {
                 return Option.some(methodDeclarationBlockCursor);
             }
         }
-        return Option.none();
+        return Option.fromNull(lambdaBodyBlockCursor);
     }
 
 

--- a/src/test/java/org/openrewrite/analysis/dataflow/HigherOrderFlowTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/HigherOrderFlowTest.java
@@ -79,6 +79,42 @@ class HigherOrderFlowTest implements RewriteTest {
     }
 
     @Test
+    void outOfCallbackComputeIfAbsentResultFlowsOnward() {
+        // Map.computeIfAbsent has two OUT callback models (the function's return value flows to both
+        // the call result and into the map's values). Both match argument 1, so the engine must pick
+        // the call-result edge deterministically and then keep following the flow through the
+        // subsequent statements; routing to the qualifier instead would dead-end here.
+        rewriteRun(
+          java(
+            """
+              import java.util.Map;
+              class Test {
+                  String source() { return null; }
+                  void sink(Object o) {}
+                  void test(Map<String, String> map) {
+                      String name = map.computeIfAbsent("k", key -> source());
+                      String alias = name;
+                      sink(alias);
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+              class Test {
+                  String source() { return null; }
+                  void sink(Object o) {}
+                  void test(Map<String, String> map) {
+                      String name = /*~~>*/map.computeIfAbsent("k", key -> /*~~>*/source());
+                      String alias = /*~~>*/name;
+                      sink(/*~~>*/alias);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void outOfCallbackComputeIfAbsentBlockBodyIsLimited() {
         // Known limitation: when the source sits inside a *block-body* lambda, control-flow
         // reachability is scoped to the lambda body (a block body forms its own control-flow

--- a/src/test/java/org/openrewrite/analysis/dataflow/HigherOrderFlowTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/HigherOrderFlowTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.dataflow;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.analysis.trait.expr.MethodAccess;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * Higher-order ("lambda call") data flow: flow into a lambda argument's parameter and out of its
+ * return value, driven by the CodeQL-derived callback models in {@code model.csv}.
+ */
+@SuppressWarnings("FunctionName")
+class HigherOrderFlowTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new FindLocalFlowPaths<>(new TaintFlowSpec() {
+            @Override
+            public boolean isSource(DataFlowNode srcNode) {
+                return srcNode
+                  .asExpr(MethodAccess.class)
+                  .map(MethodAccess::getSimpleName)
+                  .map("source"::equals)
+                  .orSome(false);
+            }
+
+            @Override
+            public boolean isSink(DataFlowNode sinkNode) {
+                return true;
+            }
+        }))).expectedCyclesThatMakeChanges(1).cycles(1);
+    }
+
+    @DocumentExample
+    @Test
+    void outOfCallbackComputeIfAbsentExpressionBody() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Map;
+              class Test {
+                  String source() { return null; }
+                  void test(Map<String, String> map) {
+                      String v = map.computeIfAbsent("k", key -> source());
+                      System.out.println(v);
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+              class Test {
+                  String source() { return null; }
+                  void test(Map<String, String> map) {
+                      String v = /*~~>*/map.computeIfAbsent("k", key -> /*~~>*/source());
+                      System.out.println(/*~~>*/v);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void outOfCallbackComputeIfAbsentBlockBodyIsLimited() {
+        // Known limitation: when the source sits inside a *block-body* lambda, control-flow
+        // reachability is scoped to the lambda body (a block body forms its own control-flow
+        // region), so flow does not escape through the lambda's `return` to the enclosing call
+        // result. Expression-body lambdas (see above) are not subject to this. Lifting it requires
+        // reworking how a lambda's `return` reachability connects to the enclosing flow, which has
+        // subtle interactions with the existing expression-body behavior. Mirrors the block-body
+        // limitation documented in FindLocalFlowPathsAnonymousClassTest.
+        rewriteRun(
+          java(
+            """
+              import java.util.Map;
+              class Test {
+                  String source() { return null; }
+                  void test(Map<String, String> map) {
+                      String v = map.computeIfAbsent("k", key -> {
+                          return source();
+                      });
+                      System.out.println(v);
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+              class Test {
+                  String source() { return null; }
+                  void test(Map<String, String> map) {
+                      String v = map.computeIfAbsent("k", key -> {
+                          return /*~~>*/source();
+                      });
+                      System.out.println(v);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void intoCallbackForEachBlockBody() {
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              class Test {
+                  List<String> source() { return null; }
+                  void sink(Object o) {}
+                  void test() {
+                      List<String> list = source();
+                      list.forEach(x -> {
+                          sink(x);
+                      });
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              class Test {
+                  List<String> source() { return null; }
+                  void sink(Object o) {}
+                  void test() {
+                      List<String> list = /*~~>*/source();
+                      /*~~>*/list.forEach(/*~~>*/x -> {
+                          sink(/*~~>*/x);
+                      });
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void intoCallbackForEach() {
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              class Test {
+                  List<String> source() { return null; }
+                  void test() {
+                      List<String> list = source();
+                      list.forEach(x -> System.out.println(x));
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              class Test {
+                  List<String> source() { return null; }
+                  void test() {
+                      List<String> list = /*~~>*/source();
+                      /*~~>*/list.forEach(/*~~>*/x -> System.out.println(/*~~>*/x));
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/analysis/dataflow/HigherOrderFlowTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/HigherOrderFlowTest.java
@@ -115,14 +115,9 @@ class HigherOrderFlowTest implements RewriteTest {
     }
 
     @Test
-    void outOfCallbackComputeIfAbsentBlockBodyIsLimited() {
-        // Known limitation: when the source sits inside a *block-body* lambda, control-flow
-        // reachability is scoped to the lambda body (a block body forms its own control-flow
-        // region), so flow does not escape through the lambda's `return` to the enclosing call
-        // result. Expression-body lambdas (see above) are not subject to this. Lifting it requires
-        // reworking how a lambda's `return` reachability connects to the enclosing flow, which has
-        // subtle interactions with the existing expression-body behavior. Mirrors the block-body
-        // limitation documented in FindLocalFlowPathsAnonymousClassTest.
+    void outOfCallbackComputeIfAbsentBlockBody() {
+        // A block-body lambda's `return` escapes to the enclosing call result just like an
+        // expression-body lambda: the source flows out of computeIfAbsent into `v`.
         rewriteRun(
           java(
             """
@@ -142,10 +137,10 @@ class HigherOrderFlowTest implements RewriteTest {
               class Test {
                   String source() { return null; }
                   void test(Map<String, String> map) {
-                      String v = map.computeIfAbsent("k", key -> {
+                      String v = /*~~>*/map.computeIfAbsent("k", key -> {
                           return /*~~>*/source();
                       });
-                      System.out.println(v);
+                      System.out.println(/*~~>*/v);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/analysis/dataflow/internal/csv/AccessPathTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/internal/csv/AccessPathTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.dataflow.internal.csv;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.analysis.dataflow.internal.csv.AccessPath.CallbackKind;
+import org.openrewrite.analysis.dataflow.internal.csv.AccessPath.Root;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AccessPathTest {
+
+    @Test
+    void flatArgument() {
+        AccessPath ap = AccessPath.parse("Argument[0]").orElseThrow();
+        assertThat(ap.getRoot()).isEqualTo(Root.ARGUMENT);
+        assertThat(ap.getRootRange()).isEqualTo(new GenericExternalModel.ArgumentRange(0, 0));
+        assertThat(ap.getCallbackKind()).isEqualTo(CallbackKind.NONE);
+        assertThat(ap.isCallback()).isFalse();
+    }
+
+    @Test
+    void qualifierArgument() {
+        AccessPath ap = AccessPath.parse("Argument[-1]").orElseThrow();
+        assertThat(ap.getRoot()).isEqualTo(Root.ARGUMENT);
+        assertThat(ap.getRootRange()).isEqualTo(new GenericExternalModel.ArgumentRange(-1, -1));
+        assertThat(ap.getCallbackKind()).isEqualTo(CallbackKind.NONE);
+    }
+
+    @Test
+    void argumentRange() {
+        AccessPath ap = AccessPath.parse("Argument[0..2]").orElseThrow();
+        assertThat(ap.getRootRange()).isEqualTo(new GenericExternalModel.ArgumentRange(0, 2));
+    }
+
+    @Test
+    void returnValueRoot() {
+        AccessPath ap = AccessPath.parse("ReturnValue").orElseThrow();
+        assertThat(ap.getRoot()).isEqualTo(Root.RETURN_VALUE);
+        assertThat(ap.getCallbackKind()).isEqualTo(CallbackKind.NONE);
+    }
+
+    @Test
+    void contentCollapsesToContainer() {
+        // Element / MapKey / MapValue / ArrayElement / Field / SyntheticField are collapsed away.
+        assertThat(AccessPath.parse("Argument[-1].Element").orElseThrow().getRootRange())
+                .isEqualTo(new GenericExternalModel.ArgumentRange(-1, -1));
+        assertThat(AccessPath.parse("Argument[-1].Element").orElseThrow().getCallbackKind())
+                .isEqualTo(CallbackKind.NONE);
+        assertThat(AccessPath.parse("ReturnValue.Element").orElseThrow().getRoot())
+                .isEqualTo(Root.RETURN_VALUE);
+        assertThat(AccessPath.parse("Argument[0].SyntheticField[com.google.common.collect.Table.rowKey]").orElseThrow().getRootRange())
+                .isEqualTo(new GenericExternalModel.ArgumentRange(0, 0));
+        assertThat(AccessPath.parse("Argument[0].MapValue.Element").orElseThrow().getRootRange())
+                .isEqualTo(new GenericExternalModel.ArgumentRange(0, 0));
+    }
+
+    @Test
+    void callbackParameter() {
+        AccessPath ap = AccessPath.parse("Argument[0].Parameter[1]").orElseThrow();
+        assertThat(ap.getRoot()).isEqualTo(Root.ARGUMENT);
+        assertThat(ap.getRootRange()).isEqualTo(new GenericExternalModel.ArgumentRange(0, 0));
+        assertThat(ap.getCallbackKind()).isEqualTo(CallbackKind.PARAMETER);
+        assertThat(ap.getCallbackRange()).isEqualTo(new GenericExternalModel.ArgumentRange(1, 1));
+        assertThat(ap.isCallback()).isTrue();
+    }
+
+    @Test
+    void callbackParameterWithTrailingContent() {
+        AccessPath ap = AccessPath.parse("Argument[0].Parameter[0].Element").orElseThrow();
+        assertThat(ap.getCallbackKind()).isEqualTo(CallbackKind.PARAMETER);
+        assertThat(ap.getCallbackRange()).isEqualTo(new GenericExternalModel.ArgumentRange(0, 0));
+    }
+
+    @Test
+    void callbackReturnValue() {
+        AccessPath ap = AccessPath.parse("Argument[1].ReturnValue").orElseThrow();
+        assertThat(ap.getRoot()).isEqualTo(Root.ARGUMENT);
+        assertThat(ap.getRootRange()).isEqualTo(new GenericExternalModel.ArgumentRange(1, 1));
+        assertThat(ap.getCallbackKind()).isEqualTo(CallbackKind.RETURN_VALUE);
+        assertThat(ap.isCallback()).isTrue();
+    }
+
+    @Test
+    void callbackReturnValueWithTrailingContent() {
+        AccessPath ap = AccessPath.parse("Argument[1].ReturnValue.Element").orElseThrow();
+        assertThat(ap.getCallbackKind()).isEqualTo(CallbackKind.RETURN_VALUE);
+    }
+
+    @Test
+    void emptyIsUnparseable() {
+        assertThat(AccessPath.parse("")).isEmpty();
+    }
+
+    @Test
+    void unknownRootIsUnparseable() {
+        assertThat(AccessPath.parse("Bogus")).isEmpty();
+    }
+}


### PR DESCRIPTION
## Motivation

The data-flow analysis (modeled after CodeQL) loads CodeQL's flow summaries from `model.csv`, but the access-path parser only understood flat `Argument[i]` / `ReturnValue` paths. CodeQL access paths that reference a *functional* argument's parameter or return value — e.g. `Argument[0].Parameter[0]`, `Argument[1].ReturnValue` — were silently dropped (the parser's full-string regex didn't match them). As a result the higher-order summaries already present in `model.csv` (`Iterable.forEach`, `Stream.map`, `Map.computeIfAbsent`, …) carried no flow.

- This adds the parsing and the engine dispatch for higher-order ("lambda call") flow, mirroring CodeQL's `lambdaCall` / `lambdaCreation`: data can flow *into* a lambda argument's parameter and *out* of its return value. It builds on #101 (lambda-parameter modeling), reusing `LambdaExpr.asMethod()` and the lambda-body traversal.

## Examples

```java
// OUT-of-callback: the mapping function's return value flows to the call result
String v = map.computeIfAbsent("k", key -> source());   // v carries source()'s taint

// OUT-of-callback also escapes a block-body lambda's `return`
String w = map.computeIfAbsent("k", key -> { return source(); });   // w carries the taint

// INTO-callback: the receiver's elements flow to the consumer's parameter
List<String> list = source();
list.forEach(x -> sink(x));                              // x carries source()'s taint
```

## Summary

- `internal/csv/AccessPath` — a structured, bracket-aware parser for CodeQL access paths. It extracts a root (`Argument[i]` / `ReturnValue`) plus an optional callback component (`Parameter[j]` / a callback `ReturnValue`), and collapses content components (`Element` / `MapKey` / `MapValue` / `ArrayElement` / `Field` / `SyntheticField`) onto their container — an over-approximation consistent with the engine's whole-value granularity.
- `ExternalFlowModels` classifies callback rows into `CallbackFlowModel`s (`INTO` / `OUT`), exposed via `DataFlowSpec.callbackFlowModels` (`TaintFlowSpec` adds taint). Content collapse is applied **only** to callback rows; pure content rows stay inert (activating them is a separate content-flow feature, out of scope).
- `ForwardFlow` dispatches both directions: `INTO` seeds the lambda parameter (reusing the lambda-body traversal); `OUT` routes the lambda result to the call's output node and continues the flow from there — including out of a **block-body** lambda's `return` (`CursorUtil.findCallableBlockCursor` scopes a source inside a block-body lambda to its enclosing method so reachability covers the call result). When several OUT models match one call (e.g. `Map.computeIfAbsent` maps the function's result to both the call result and the map's contents), it deterministically prefers the call-result edge rather than depending on model iteration order.
- `Parameter.getPosition()` is now computed directly from the LST instead of `callable.getParameters().indexOf(this)`, which rebuilt the parameter list (and, for lambdas, a fresh `Method` per parameter) on every call — O(n²) to position all parameters.

**Known limitation:** higher-order OUT flow is routed for lambda arguments only, not anonymous-class functional implementations. Content-flow (e.g. taint stored into a map and later read back) remains out of scope.

## Test plan

- [x] `AccessPathTest` — parser unit tests: flat paths, argument ranges, content collapse, callback `Parameter`/`ReturnValue`, unparseable inputs.
- [x] `HigherOrderFlowTest` — OUT (`computeIfAbsent`, expression **and block** bodies, plus onward propagation from the call result), INTO (`forEach`, expression and block bodies).
- [x] `ParameterTest` / `LambdaExprTest` — positions still correct after the `getPosition()` change.
- [x] Full module test suite green — no regressions; higher-order flow verified deterministic across repeated fresh-JVM runs.
