### PR TITLE
Support higher-order ("lambda call") sinks

### DIFF
--- a/src/main/java/org/openrewrite/analysis/dataflow/ExternalSinkModels.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/ExternalSinkModels.java
@@ -19,14 +19,18 @@ import lombok.*;
 import org.openrewrite.Cursor;
 import org.openrewrite.Incubating;
 import org.openrewrite.analysis.InvocationMatcher;
+import org.openrewrite.analysis.dataflow.internal.LambdaReturns;
+import org.openrewrite.analysis.dataflow.internal.csv.AccessPath;
 import org.openrewrite.analysis.dataflow.internal.csv.CsvLoader;
 import org.openrewrite.analysis.dataflow.internal.csv.GenericExternalModel;
 import org.openrewrite.analysis.dataflow.internal.csv.Mergeable;
 import org.openrewrite.analysis.trait.expr.Call;
 import org.openrewrite.java.internal.TypesInUse;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.MethodCall;
 
 import java.lang.ref.SoftReference;
 import java.util.*;
@@ -198,18 +202,85 @@ public final class ExternalSinkModels {
             return sinkNode -> sinkNode.asExprParent(Call.class).map(call -> call.matches(invocationMatcher)).orSome(false);
         }
 
+        /**
+         * A predicate for higher-order ("lambda call") sinks spelled {@code Argument[i].ReturnValue}: the
+         * sink is the value <em>returned by the lambda passed as argument {@code callbackArgument}</em>.
+         * Ordinary forward flow already reaches a value captured into a lambda body, so unlike the flow
+         * side this needs no edge routing — only recognizing that the node is such a return value.
+         */
+        private SinkNodePredicate sinkNodePredicateForCallbackReturnValue(
+                int callbackArgument,
+                Collection<? extends GenericExternalModel> methodMatchers
+        ) {
+            InvocationMatcher invocationMatcher = GenericExternalModel.indexedMatcher(methodMatchers);
+            return sinkNode -> isCallbackReturnValueSink(sinkNode.getCursor(), callbackArgument, invocationMatcher);
+        }
+
+        /**
+         * Holds if the node at {@code nodeCursor} is the return value of a lambda that is passed as
+         * argument {@code callbackArgument} of a call matching {@code matcher}.
+         */
+        private static boolean isCallbackReturnValueSink(Cursor nodeCursor, int callbackArgument, InvocationMatcher matcher) {
+            Cursor lambdaCursor = null;
+            for (Iterator<Cursor> it = nodeCursor.getPathAsCursors(); it.hasNext(); ) {
+                Cursor c = it.next();
+                if (c.getValue() instanceof J.Lambda) {
+                    lambdaCursor = c;
+                    break;
+                }
+            }
+            if (lambdaCursor == null) {
+                return false;
+            }
+            J.Lambda lambda = lambdaCursor.getValue();
+            if (!LambdaReturns.isLambdaResult(nodeCursor, lambda)) {
+                return false;
+            }
+            // The lambda may be wrapped (a cast or parentheses), so the enclosing call is its nearest
+            // method call and the argument match is by unwrapped identity, mirroring the flow side.
+            MethodCall call = lambdaCursor.firstEnclosing(MethodCall.class);
+            if (call == null) {
+                return false;
+            }
+            List<Expression> arguments = call.getArguments();
+            if (arguments == null || callbackArgument < 0 || callbackArgument >= arguments.size()) {
+                return false;
+            }
+            if (arguments.get(callbackArgument).unwrap() != lambda) {
+                return false;
+            }
+            return matcher.matches(call.getMethodType());
+        }
+
         private Set<PredicateToSinkModels> optimize(Collection<SinkModel> models) {
             Map<Integer, Set<SinkModel>> sinkForArgument = new HashMap<>();
             // Uncommon, so don't allocate unless needed
             Set<SinkModel> sinkForReturnValue = new HashSet<>(0);
+            // Higher-order ("lambda call") sinks `Argument[i].ReturnValue`, keyed by callback argument
+            // index. Rare, so don't allocate unless needed.
+            Map<Integer, Set<SinkModel>> sinkForCallbackReturnValue = new HashMap<>(0);
             for (SinkModel model : models) {
-                model.getArgumentRange().ifPresent(argumentRange -> {
-                    for (int i = argumentRange.getStart(); i <= argumentRange.getEnd(); i++) {
+                Optional<GenericExternalModel.ArgumentRange> argumentRange = model.getArgumentRange();
+                if (argumentRange.isPresent()) {
+                    GenericExternalModel.ArgumentRange range = argumentRange.get();
+                    for (int i = range.getStart(); i <= range.getEnd(); i++) {
                         sinkForArgument.computeIfAbsent(i, __ -> new HashSet<>()).add(model);
                     }
-                });
-                if ("ReturnValue".equals(model.input)) {
+                } else if ("ReturnValue".equals(model.input)) {
                     sinkForReturnValue.add(model);
+                } else if (model.input.indexOf('.') >= 0) {
+                    // A `.`-containing input that is not a bare argument range. The only higher-order
+                    // sink shape this content-insensitive engine models is `Argument[i].ReturnValue`
+                    // (the value returned by the lambda passed as argument i).
+                    AccessPath.parse(model.input).ifPresent(path -> {
+                        if (path.getRoot() == AccessPath.Root.ARGUMENT &&
+                            path.getCallbackKind() == AccessPath.CallbackKind.RETURN_VALUE) {
+                            GenericExternalModel.ArgumentRange range = path.getRootRange();
+                            for (int i = range.getStart(); i <= range.getEnd(); i++) {
+                                sinkForCallbackReturnValue.computeIfAbsent(i, __ -> new HashSet<>()).add(model);
+                            }
+                        }
+                    });
                 }
             }
             Stream<PredicateToSinkModels> predicateToSinkModelsStream =
@@ -225,8 +296,19 @@ public final class ExternalSinkModels {
                             sinkNodePredicateForReturnValue(sinkForReturnValue),
                             sinkForReturnValue
                     ));
+            Stream<PredicateToSinkModels> callbackReturnValuePredicateToSinkModelsStream =
+                    sinkForCallbackReturnValue
+                            .entrySet()
+                            .stream()
+                            .map(entry -> new PredicateToSinkModels(
+                                    sinkNodePredicateForCallbackReturnValue(entry.getKey(), entry.getValue()),
+                                    entry.getValue()
+                            ));
             return Stream
-                    .concat(predicateToSinkModelsStream, returnValuePredicateToSinkModelsStream)
+                    .concat(
+                            Stream.concat(predicateToSinkModelsStream, returnValuePredicateToSinkModelsStream),
+                            callbackReturnValuePredicateToSinkModelsStream
+                    )
                     .collect(toSet());
         }
 

--- a/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
@@ -25,6 +25,7 @@ import org.openrewrite.analysis.InvocationMatcher;
 import org.openrewrite.analysis.dataflow.CallbackFlowModel;
 import org.openrewrite.analysis.dataflow.DataFlowNode;
 import org.openrewrite.analysis.dataflow.DataFlowSpec;
+import org.openrewrite.analysis.dataflow.internal.LambdaReturns;
 import org.openrewrite.analysis.trait.expr.Call;
 import org.openrewrite.analysis.trait.expr.VarAccess;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -645,7 +646,7 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                 continue;
             }
             J.Lambda lambda = (J.Lambda) unwrapped;
-            if (!isAncestor(lambda, currentCursor) || !isLambdaResult(currentCursor, lambda)) {
+            if (!isAncestor(lambda, currentCursor) || !LambdaReturns.isLambdaResult(currentCursor, lambda)) {
                 continue;
             }
             // A single call/argument can match several OUT models. Map.computeIfAbsent, for instance,
@@ -802,21 +803,5 @@ public class ForwardFlow extends JavaVisitor<Integer> {
             }
         }
         return false;
-    }
-
-    /** Holds if the node at {@code nodeCursor} is (the expression of) the lambda's return value. */
-    private static boolean isLambdaResult(Cursor nodeCursor, J.Lambda lambda) {
-        J node = nodeCursor.getValue();
-        J body = lambda.getBody();
-        if (!(body instanceof J.Block)) {
-            return body instanceof Expression && Expression.unwrap((Expression) body) == node;
-        }
-        J.Return aReturn = nodeCursor.firstEnclosing(J.Return.class);
-        if (aReturn == null || aReturn.getExpression() == null ||
-            Expression.unwrap(aReturn.getExpression()) != node) {
-            return false;
-        }
-        // The return must belong to this lambda, not a nested lambda or anonymous-class method.
-        return nodeCursor.firstEnclosing(J.Lambda.class) == lambda;
     }
 }

--- a/src/main/java/org/openrewrite/analysis/dataflow/internal/LambdaReturns.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/internal/LambdaReturns.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.dataflow.internal;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.openrewrite.Cursor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+/**
+ * Helpers for reasoning about the return value of a lambda — the value that "flows out" of a
+ * functional argument. Shared by the higher-order ("lambda call") data-flow engine and the
+ * higher-order sink models so both agree on exactly which expressions count as a lambda's result.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class LambdaReturns {
+
+    /** Holds if the node at {@code nodeCursor} is (the expression of) {@code lambda}'s return value. */
+    public static boolean isLambdaResult(Cursor nodeCursor, J.Lambda lambda) {
+        J node = nodeCursor.getValue();
+        J body = lambda.getBody();
+        if (!(body instanceof J.Block)) {
+            return body instanceof Expression && Expression.unwrap((Expression) body) == node;
+        }
+        J.Return aReturn = nodeCursor.firstEnclosing(J.Return.class);
+        if (aReturn == null || aReturn.getExpression() == null ||
+            Expression.unwrap(aReturn.getExpression()) != node) {
+            return false;
+        }
+        // The return must belong to this lambda, not a nested lambda or anonymous-class method.
+        return nodeCursor.firstEnclosing(J.Lambda.class) == lambda;
+    }
+}

--- a/src/test/java/org/openrewrite/analysis/dataflow/ExternalSinkModelsTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/ExternalSinkModelsTest.java
@@ -37,13 +37,13 @@ class ExternalSinkModelsTest {
         // Remove all optimized sink flow models
         models.removeAll(optimizedModels.getSinkModels());
 
-        // Every plain sink (a bare `Argument[...]` position or `ReturnValue`) must be optimized. The
-        // only sinks that may remain are those whose input is a content or higher-order ("callback")
-        // access path — e.g. `Argument[0].ReturnValue` (the return value of a functional argument) or
-        // `Argument[this].MapValue` — which this content-insensitive engine does not model.
+        // Every sink in the current model set must be optimized: bare `Argument[...]` positions,
+        // `ReturnValue`, and the higher-order `Argument[i].ReturnValue` ("lambda call") sinks. If a new
+        // CodeQL regeneration introduces a sink shape this engine does not yet model (e.g. a content
+        // access path like `Argument[this].MapValue`), it would surface here.
         assertThat(models)
-                .as("Only content/callback sinks may remain unoptimized")
-                .allMatch(model -> model.input.contains("."));
+                .as("Every sink must be optimized")
+                .isEmpty();
     }
 
     @Test

--- a/src/test/java/org/openrewrite/analysis/dataflow/HigherOrderSinkTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/HigherOrderSinkTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.dataflow;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.analysis.trait.expr.MethodAccess;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * Higher-order ("lambda call") sinks: a sink whose access path is {@code Argument[i].ReturnValue}
+ * marks the value <em>returned by the lambda passed as argument {@code i}</em> as the sink. The
+ * canonical example is Couchbase's {@code PasswordAuthenticator.Builder.password(Supplier)}, whose
+ * supplier's return value is a {@code credentials-password} sink.
+ */
+@SuppressWarnings("FunctionName")
+class HigherOrderSinkTest implements RewriteTest {
+
+    /**
+     * A minimal stub of the Couchbase type carrying the real {@code Argument[0].ReturnValue} sink
+     * models, so the test exercises the shipped {@code sinks.csv} data without a Couchbase dependency.
+     */
+    //language=java
+    private static final String PASSWORD_AUTHENTICATOR = """
+      package com.couchbase.client.core.env;
+
+      import java.util.function.Supplier;
+
+      public class PasswordAuthenticator {
+          public static Builder builder() {
+              return new Builder();
+          }
+
+          public static class Builder {
+              public Builder username(Supplier<String> username) {
+                  return this;
+              }
+
+              public Builder password(Supplier<String> password) {
+                  return this;
+              }
+          }
+      }
+      """;
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new FindLocalFlowPaths<>(new TaintFlowSpec() {
+            @Override
+            public boolean isSource(DataFlowNode srcNode) {
+                return srcNode
+                  .asExpr(MethodAccess.class)
+                  .map(MethodAccess::getSimpleName)
+                  .map("source"::equals)
+                  .orSome(false);
+            }
+
+            @Override
+            public boolean isSink(DataFlowNode sinkNode) {
+                return ExternalSinkModels.instance().isSinkNode(sinkNode, "credentials-password");
+            }
+        }))).expectedCyclesThatMakeChanges(1).cycles(1);
+    }
+
+    @DocumentExample
+    @Test
+    void sinkAtExpressionBodyLambdaReturn() {
+        rewriteRun(
+          java(PASSWORD_AUTHENTICATOR),
+          java(
+            """
+              import com.couchbase.client.core.env.PasswordAuthenticator;
+              class Test {
+                  String source() { return null; }
+                  void test() {
+                      String secret = source();
+                      PasswordAuthenticator.builder().password(() -> secret);
+                  }
+              }
+              """,
+            """
+              import com.couchbase.client.core.env.PasswordAuthenticator;
+              class Test {
+                  String source() { return null; }
+                  void test() {
+                      String secret = /*~~>*/source();
+                      PasswordAuthenticator.builder().password(() -> /*~~>*/secret);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void sinkAtBlockBodyLambdaReturn() {
+        rewriteRun(
+          java(PASSWORD_AUTHENTICATOR),
+          java(
+            """
+              import com.couchbase.client.core.env.PasswordAuthenticator;
+              class Test {
+                  String source() { return null; }
+                  void test() {
+                      String secret = source();
+                      PasswordAuthenticator.builder().password(() -> {
+                          return secret;
+                      });
+                  }
+              }
+              """,
+            """
+              import com.couchbase.client.core.env.PasswordAuthenticator;
+              class Test {
+                  String source() { return null; }
+                  void test() {
+                      String secret = /*~~>*/source();
+                      PasswordAuthenticator.builder().password(() -> {
+                          return /*~~>*/secret;
+                      });
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noSinkWhenValueIsNotReturnedFromLambda() {
+        // The tainted value is used inside the lambda but is not its return value, so it is not a
+        // `Argument[0].ReturnValue` sink. No source -> sink path exists, so nothing is marked.
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(0),
+          java(PASSWORD_AUTHENTICATOR),
+          java(
+            """
+              import com.couchbase.client.core.env.PasswordAuthenticator;
+              class Test {
+                  String source() { return null; }
+                  void test() {
+                      String secret = source();
+                      PasswordAuthenticator.builder().password(() -> {
+                          System.out.println(secret);
+                          return "constant";
+                      });
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noSinkWhenLambdaPassedToNonMatchingMethod() {
+        // The same lambda shape passed to a method with no callback-return sink model is not a sink.
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(0),
+          java(
+            """
+              import java.util.function.Supplier;
+              class Test {
+                  String source() { return null; }
+                  void consume(Supplier<String> s) {}
+                  void test() {
+                      String secret = source();
+                      consume(() -> secret);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

- A CodeQL-derived sink model can place the sink at the **return value of a functional argument**, spelled `Argument[i].ReturnValue` — meaning "the value returned by the lambda passed as argument `i` is the sink." The current model regeneration (#103) surfaced four such sinks: Couchbase's `PasswordAuthenticator.builder/password/username(Supplier)` (kinds `credentials-password` / `credentials-username`), where the supplier's return value is the credential.

- `ExternalSinkModels.Optimizer` had no way to express this shape, so it silently dropped those rows — a `Supplier`-returned credential flowing to one of these methods would not be detected as a sink. This is the sink-side analog of the higher-order *flow* support added in #102.

The key observation is that, unlike the flow side, **no new flow machinery is needed**: ordinary forward flow already reaches a value captured into a lambda body. The sink side only has to *recognize* that a node is the lambda's return value — so this change is just a new sink predicate, not new edge routing.

## Examples

A tainted value returned by the supplier is now detected as a `credentials-password` sink:

```java
String secret = source();
PasswordAuthenticator.builder().password(() -> secret); // `secret` is a credentials-password sink
```

Block-body lambdas work the same way (the `return`ed value is the sink), and the value must actually be *returned* — a value merely used inside the lambda (e.g. logged) is not flagged.

## Summary

- Extract `ForwardFlow.isLambdaResult` into a shared `LambdaReturns` helper so the flow engine and the sink models agree on exactly which expressions count as a lambda's result (expression bodies, block-body `return`, nested-lambda exclusion).
- Add a callback-return-value bucket and `sinkNodePredicateForCallbackReturnValue` predicate to `ExternalSinkModels.Optimizer`, parsing `Argument[i].ReturnValue` inputs via `AccessPath`. The predicate walks node → enclosing lambda → enclosing call, confirming the node is the lambda's return value, the lambda is argument `i` (by unwrapped identity, so casts/parens are tolerated), and the call matches.
- Tighten `ExternalSinkModelsTest.listSinkModelsOptimized`: it now asserts every sink is optimized (`isEmpty()`), where it previously had to allow these callback sinks to remain unoptimized. A future regeneration introducing an unmodeled sink shape will surface here.

## Test plan

- [x] New `HigherOrderSinkTest`, exercising the real shipped `sinks.csv` Couchbase models via an inline type stub (no Couchbase dependency):
  - [x] expression-body lambda return is a sink
  - [x] block-body lambda return is a sink
  - [x] value used inside the lambda but **not** returned is not a sink
  - [x] same lambda shape passed to a method with no callback-return model is not a sink
- [x] `ExternalSinkModelsTest` tightened assertion passes (every sink optimized).
- [x] `HigherOrderFlowTest` + `FindLocalTaintFlowToExternalSinkTest` green — the `isLambdaResult` extraction is behavior-preserving.
- [x] Full module test suite green.