### PR TITLE
Build data-flow node failure messages lazily

### DIFF
--- a/src/main/java/org/openrewrite/analysis/dataflow/DataFlowNode.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/DataFlowNode.java
@@ -77,6 +77,20 @@ public abstract class DataFlowNode {
         }
         return maybeNode.some();
     }
+
+    /**
+     * Like {@link #ofOrThrow(Cursor, String)} but builds the failure message lazily. The hot data-flow
+     * traversal calls this on every candidate node and never actually throws here; eagerly concatenating
+     * {@code cursor} (whose {@link Cursor#toString()} prints the enclosing tree) dominated allocation, so
+     * the message is only constructed on the never-taken failure path.
+     */
+    public static DataFlowNode ofOrThrow(Cursor cursor) {
+        Option<DataFlowNode> maybeNode = of(cursor);
+        if (maybeNode.isNone()) {
+            throw new RuntimeException("Unable to create DataFlowNode for " + cursor);
+        }
+        return maybeNode.some();
+    }
 }
 
 class ExpressionDataFlowNode extends DataFlowNode {

--- a/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/analysis/ForwardFlow.java
@@ -233,7 +233,7 @@ public class ForwardFlow extends JavaVisitor<Integer> {
             }
             Iterator<FlowGraph> iterator = get(identifier).iterator();
             FlowGraph flow = iterator.next();
-            DataFlowNode flowNode = DataFlowNode.ofOrThrow(cursor, "identifier is not a DataFlowNode: " + cursor);
+            DataFlowNode flowNode = DataFlowNode.ofOrThrow(cursor);
             // Create a FlowGraph for the current identifier being visited
             FlowGraph newFlowGraph = flow.addEdge(flowNode);
             while (iterator.hasNext()) {
@@ -456,7 +456,7 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                         // Select may not be a data flow node if it's a static access
                         Option<DataFlowNode> selectNode = DataFlowNode.of(selectCursor);
                         if (selectNode.isSome() && spec.isFlowStep(
-                                DataFlowNode.ofOrThrow(previousCursor, "Unable to create DataFlowNode for " + previousCursor),
+                                DataFlowNode.ofOrThrow(previousCursor),
                                 selectNode.some()
                         )) {
                             nextFlowGraph = nextFlowGraph.addEdge(selectNode.some());
@@ -482,10 +482,10 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                             }
 
                             Cursor argumentCursor = new Cursor(parentCursor, expr);
-                            DataFlowNode argumentNode = DataFlowNode.ofOrThrow(argumentCursor, "Unable to create DataFlowNode for " + argumentCursor);
+                            DataFlowNode argumentNode = DataFlowNode.ofOrThrow(argumentCursor);
 
                             if (spec.isFlowStep(
-                                    DataFlowNode.ofOrThrow(previousCursor, "Unable to create DataFlowNode for " + previousCursor),
+                                    DataFlowNode.ofOrThrow(previousCursor),
                                     argumentNode
                             )) {
                                 nextFlowGraph = nextFlowGraph.addEdge(argumentNode);
@@ -521,10 +521,10 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                             }
 
                             Cursor argumentCursor = new Cursor(parentCursor, expr);
-                            DataFlowNode argumentNode = DataFlowNode.ofOrThrow(argumentCursor, "Unable to create DataFlowNode for " + argumentCursor);
+                            DataFlowNode argumentNode = DataFlowNode.ofOrThrow(argumentCursor);
 
                             if (spec.isFlowStep(
-                                    DataFlowNode.ofOrThrow(previousCursor, "Unable to create DataFlowNode for " + previousCursor),
+                                    DataFlowNode.ofOrThrow(previousCursor),
                                     argumentNode
                             )) {
                                 nextFlowGraph = nextFlowGraph.addEdge(argumentNode);
@@ -542,7 +542,7 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                     }
                 }
                 if (spec.isFlowStep(
-                        DataFlowNode.ofOrThrow(previousCursor, "Unable to create DataFlowNode for " + previousCursor),
+                        DataFlowNode.ofOrThrow(previousCursor),
                         ancestorNode
                 )) {
                     nextFlowGraph = nextFlowGraph.addEdge(ancestorNode);


### PR DESCRIPTION
## Motivation

The forward data-flow traversal calls `DataFlowNode.ofOrThrow(cursor, "Unable to create DataFlowNode for " + cursor)` on essentially every candidate node it walks. The failure message was built **eagerly** at the call site, even though the call never throws on the happy path — and `Cursor.toString()` prints the cursor's *enclosing tree* via `JavaPrinter`. So each of these calls printed a tree subtree into a `String` and immediately discarded it.

Allocation profiling of `DataFlowMatchingBenchmark` (async-profiler, `event=alloc`) made this stark:

- **72%** of all allocation was `byte[]`, and **~66% of all allocation** traced to `Cursor.toString()` reached *only* through these eager exception messages.
- Attribution: 84.6% from `ForwardFlow.computeVariableAssignment`, 15.4% from `ForwardFlow$IdentifierToFlows.addForIdentifierVisit` — both pure happy-path waste.

Because `Cursor.toString()` is also CPU-heavy (it runs the Java printer), removing it helps throughput far more than the allocation drop alone would suggest.

## Summary

- Add a `DataFlowNode.ofOrThrow(Cursor)` overload that constructs the failure message only on the never-taken throw path (the existing `ofOrThrow(Cursor, String)` is unchanged).
- Switch all seven `ForwardFlow` call sites to the lazy overload. Behavior is identical — the message is only observable when the node genuinely can't be created, which does not happen on these paths.

## Test plan

- [x] Full `org.openrewrite.analysis.dataflow.*` test suite green — behavior unchanged (only the timing of message construction moved).
- [x] `DataFlowMatchingBenchmark` (`-f 2 -wi 5 -i 5 -prof gc`), before → after:
  - allocation: **13.15 MB/op → 3.30 MB/op (−75%)**
  - throughput: **~171 → ~1059 ops/s**
  - re-profiling confirms `Cursor.toString()` no longer appears as an allocation driver.