### PR TITLE
Collapse content access paths onto their container in flow models

### DIFF
--- a/src/main/java/org/openrewrite/analysis/dataflow/ExternalFlowModels.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/ExternalFlowModels.java
@@ -233,30 +233,58 @@ final class ExternalFlowModels {
             Map<Integer, Set<FlowModel>> flowFromArgumentIndexToQualifier = new HashMap<>();
             Map<ArgumentIndices, Set<FlowModel>> flowFromArgumentIndexToArgumentIndex = new HashMap<>();
             models.forEach(model -> {
-                Optional<GenericExternalModel.ArgumentRange> inputRange = GenericExternalModel.computeArgumentRange(model.input);
-                Optional<GenericExternalModel.ArgumentRange> outputRange = GenericExternalModel.computeArgumentRange(model.output);
-                if ("ReturnValue".equals(model.output) || model.isConstructor()) {
-                    inputRange.ifPresent(argumentRange -> {
-                        for (int i = argumentRange.getStart(); i <= argumentRange.getEnd(); i++) {
-                            flowFromArgumentIndexToReturn.computeIfAbsent(i, __ -> new HashSet<>())
-                                    .add(model);
-                        }
-                    });
+                // Parse both endpoints as access paths, which collapse any content component
+                // (`Element`, `MapValue`, `Field[...]`, ...) onto its container. A content store/read
+                // thereby becomes an ordinary container-level flow that the predicates below already
+                // handle: e.g. `Collection.add: Argument[0] -> Argument[this].Element` collapses to
+                // `Argument[0] -> Argument[this]` (the value taints the whole collection) and
+                // `List.get: Argument[this].Element -> ReturnValue` to `Argument[this] -> ReturnValue`.
+                // This is content-insensitive (an over-approximation), but sound only because every
+                // store and read collapses uniformly, so the two halves still reconnect.
+                Optional<AccessPath> maybeInput = AccessPath.parse(model.input);
+                Optional<AccessPath> maybeOutput = AccessPath.parse(model.output);
+                if (!maybeInput.isPresent() || !maybeOutput.isPresent()) {
+                    // Unparseable (e.g. a `WithElement`/`WithoutElement` typestate path) -> ignore.
+                    return;
+                }
+                AccessPath input = maybeInput.get();
+                AccessPath output = maybeOutput.get();
+                if (input.isCallback() || output.isCallback()) {
+                    // Higher-order ("lambda call") endpoints are owned by buildCallbackModels.
+                    return;
+                }
+                Optional<GenericExternalModel.ArgumentRange> inputRange = input.getRoot() == AccessPath.Root.ARGUMENT ?
+                        Optional.ofNullable(input.getRootRange()) : Optional.empty();
+                Optional<GenericExternalModel.ArgumentRange> outputRange = output.getRoot() == AccessPath.Root.ARGUMENT ?
+                        Optional.ofNullable(output.getRootRange()) : Optional.empty();
+                boolean outputIsReturnValue = output.getRoot() == AccessPath.Root.RETURN_VALUE;
+                if ((outputIsReturnValue || model.isConstructor()) && inputRange.isPresent()) {
+                    GenericExternalModel.ArgumentRange argumentRange = inputRange.get();
+                    for (int i = argumentRange.getStart(); i <= argumentRange.getEnd(); i++) {
+                        flowFromArgumentIndexToReturn.computeIfAbsent(i, __ -> new HashSet<>())
+                                .add(model);
+                    }
                 }
                 // Flow into the receiver, spelled `Argument[-1]` (older dialect) or `Argument[this]`
                 // (current dialect); both resolve to position -1.
-                if (isReceiver(outputRange) && !model.isConstructor()) {
-                    inputRange.ifPresent(argumentRange -> {
-                        for (int i = argumentRange.getStart(); i <= argumentRange.getEnd(); i++) {
+                if (isReceiver(outputRange) && !model.isConstructor() && inputRange.isPresent()) {
+                    GenericExternalModel.ArgumentRange argumentRange = inputRange.get();
+                    for (int i = argumentRange.getStart(); i <= argumentRange.getEnd(); i++) {
+                        // Skip a collapsed receiver -> receiver self-flow (e.g. `Argument[this].Element
+                        // -> Argument[this].MapValue`); it carries no information, and the predicate
+                        // forbids a qualifier-to-qualifier step.
+                        if (i != -1) {
                             flowFromArgumentIndexToQualifier.computeIfAbsent(i, __ -> new HashSet<>())
                                     .add(model);
                         }
-                    });
+                    }
                 }
                 if (inputRange.isPresent() && outputRange.isPresent()) {
                     for (int i = inputRange.get().getStart(); i <= inputRange.get().getEnd(); i++) {
                         for (int j = outputRange.get().getStart(); j <= outputRange.get().getEnd(); j++) {
-                            if (j >= 0) {
+                            // j >= 0 excludes the receiver (handled above); i != j skips a collapsed
+                            // self-flow (e.g. `Argument[0].MapKey -> Argument[0].MapValue`).
+                            if (j >= 0 && i != j) {
                                 flowFromArgumentIndexToArgumentIndex.computeIfAbsent(new ArgumentIndices(i, j), __ -> new HashSet<>())
                                         .add(model);
                             }

--- a/src/main/resources/data-flow/README.md
+++ b/src/main/resources/data-flow/README.md
@@ -9,9 +9,37 @@ Notes:
 - Current CodeQL writes the receiver/qualifier as `Argument[this]` (older versions used `Argument[-1]`);
   the loader understands both. The argument selector may also be a comma-separated union and/or a range,
   e.g. `Argument[this,0]` or `Argument[0..2]`.
-- Content/field-sensitive paths (`Element`, `MapKey`, `MapValue`, `Field[...]`, ...) and higher-order
-  paths on the non-callback side are over-approximations the engine collapses or ignores; they are kept
-  in the files as-is.
+- The files are kept as-is from CodeQL; how the engine interprets content and higher-order paths is
+  described under [Content and higher-order paths](#content-and-higher-order-paths) below.
+
+## Content and higher-order paths
+
+An access path may name a *part* of a value rather than the whole value:
+
+- **Content** components — `Element` (collection/iterable), `ArrayElement`, `MapKey`/`MapValue`,
+  `Field[...]`, `SyntheticField[...]` — name an interior slot of a container.
+- **Callback** components — `Argument[i].Parameter[j]` and `Argument[i].ReturnValue` — describe flow
+  into/out of a functional argument (a lambda).
+
+This engine is **content-insensitive**: it collapses every content component onto its container. A
+store such as `Collection.add: Argument[0] -> Argument[this].Element` becomes `Argument[0] ->
+Argument[this]` (the value taints the whole collection), and a read such as `List.get:
+Argument[this].Element -> ReturnValue` becomes `Argument[this] -> ReturnValue`. The store and read
+still reconnect — at container granularity instead of slot granularity — so this is a sound
+over-approximation: it can add false positives (e.g. a tainted map key makes value reads look tainted)
+but never loses a flow, *provided every store and read collapses uniformly*. Callback paths are handled
+separately (see `CallbackFlowModel`); the few `WithElement`/`WithoutElement` typestate paths are not
+modeled and are ignored.
+
+Two known limitations, each a potential follow-up:
+
+1. **Generic signatures.** A model with an explicit signature at a generic position (e.g.
+   `Map.put` spelled `(Object,Object)` for the declared `put(K,V)`) does not match a generic call site,
+   because the matcher has no erasure for type-variable parameters. So container *writes* through such
+   methods (notably `Map.put`) are not yet tracked, even though the reads are.
+2. **Precision.** True content/field-sensitivity (tracking which slot is tainted, so `MapKey` stores
+   don't leak to `MapValue` reads) would remove the false positives above. It is a larger change that
+   would thread an access-path/content state through the flow graph, mirroring CodeQL.
 
 ## Regenerating the files
 

--- a/src/test/java/org/openrewrite/analysis/dataflow/ContentFlowTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/ContentFlowTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.analysis.dataflow;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.analysis.trait.expr.MethodAccess;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * Taint flow through container contents. CodeQL models container reads/writes with a content
+ * component ({@code Element}, {@code MapValue}, …); this content-insensitive engine collapses that
+ * component onto the container, so storing a tainted value into a container taints the whole
+ * container and reading any value back out is tainted.
+ */
+@SuppressWarnings({"FunctionName", "UnusedAssignment"})
+class ContentFlowTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new FindLocalFlowPaths<>(new TaintFlowSpec() {
+            @Override
+            public boolean isSource(DataFlowNode srcNode) {
+                return srcNode
+                  .asExpr(MethodAccess.class)
+                  .map(MethodAccess::getSimpleName)
+                  .map("source"::equals)
+                  .orSome(false);
+            }
+
+            @Override
+            public boolean isSink(DataFlowNode sinkNode) {
+                return true;
+            }
+        }))).expectedCyclesThatMakeChanges(1).cycles(1);
+    }
+
+    @DocumentExample
+    @Test
+    void collectionElementAddThenGet() {
+        // Collection.add: `Argument[0] -> Argument[this].Element` collapses to `Argument[0] -> Argument[this]`
+        // (tainting the whole list); List.get: `Argument[this].Element -> ReturnValue` collapses to a read.
+        rewriteRun(
+          java(
+            """
+              import java.util.*;
+              class Test {
+                  String source() { return null; }
+                  void sink(Object o) {}
+                  void test() {
+                      List<String> list = new ArrayList<>();
+                      list.add(source());
+                      String x = list.get(0);
+                      sink(x);
+                  }
+              }
+              """,
+            """
+              import java.util.*;
+              class Test {
+                  String source() { return null; }
+                  void sink(Object o) {}
+                  void test() {
+                      List<String> list = new ArrayList<>();
+                      /*~~>*/list.add(/*~~>*/source());
+                      String x = /*~~>*//*~~>*/list.get(0);
+                      sink(/*~~>*/x);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void mapValueReadFromTaintedMap() {
+        // Map.get: `Argument[this].MapValue -> ReturnValue` collapses to `Argument[this] -> ReturnValue`,
+        // so reading any value out of a tainted map is tainted.
+        rewriteRun(
+          java(
+            """
+              import java.util.*;
+              class Test {
+                  Map<String, String> source() { return null; }
+                  void sink(Object o) {}
+                  void test() {
+                      Map<String, String> map = source();
+                      String v = map.get("k");
+                      sink(v);
+                  }
+              }
+              """,
+            """
+              import java.util.*;
+              class Test {
+                  Map<String, String> source() { return null; }
+                  void sink(Object o) {}
+                  void test() {
+                      Map<String, String> map = /*~~>*/source();
+                      String v = /*~~>*//*~~>*/map.get("k");
+                      sink(/*~~>*/v);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void optionalOfThenGet() {
+        // Optional contents are modeled as `Element`; Optional.of stores, Optional.get reads.
+        rewriteRun(
+          java(
+            """
+              import java.util.*;
+              class Test {
+                  String source() { return null; }
+                  void sink(Object o) {}
+                  void test() {
+                      Optional<String> o = Optional.of(source());
+                      String x = o.get();
+                      sink(x);
+                  }
+              }
+              """,
+            """
+              import java.util.*;
+              class Test {
+                  String source() { return null; }
+                  void sink(Object o) {}
+                  void test() {
+                      Optional<String> o = /*~~>*/Optional.of(/*~~>*/source());
+                      String x = /*~~>*//*~~>*/o.get();
+                      sink(/*~~>*/x);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

CodeQL models container reads and writes with a **content** component on the access path — `Collection.add` is `Argument[0] -> Argument[this].Element`, `Map.get` is `Argument[this].MapValue -> ReturnValue`, `Optional.of` is `Argument[0] -> ReturnValue.Element`, and so on. Roughly **7,900** of the ~26,400 flow models carry such a component.

The flow optimizer keyed off `GenericExternalModel.computeArgumentRange`, which returns empty for any path that doesn't end in `]`. So every content-bearing model was **silently dropped** — not over-approximated, *dropped*. The result was a soundness gap (false negatives): taint did not flow through containers at all.

Verified before this change — `list.add(source()); String x = list.get(0); sink(x);` marked only the `source()` call; taint reached neither `list` nor `x`. (`DefaultFlowModels` only hardcodes String-concatenation taint, so nothing else picked these up.)

## Examples

```java
// Collections: add taints the whole list; get reads it back out
List<String> list = new ArrayList<>();
list.add(source());          // list is now tainted
String x = list.get(0);      // x is tainted

// Maps (reads): a tainted map yields tainted values
Map<String, String> map = source();
String v = map.get("k");     // v is tainted

// Optional (contents modeled as Element)
Optional<String> o = Optional.of(source());
String x = o.get();          // x is tainted
```

## How it works

Both flow endpoints are now parsed with `AccessPath`, which collapses content components onto their container. A content store/read becomes an ordinary container-level flow that the existing predicates already handle:

| Model (CodeQL) | Collapsed |
|---|---|
| `Collection.add: Argument[0] -> Argument[this].Element` | `Argument[0] -> Argument[this]` |
| `List.get: Argument[this].Element -> ReturnValue` | `Argument[this] -> ReturnValue` |
| `Collections.copy: Argument[1].Element -> Argument[0].Element` | `Argument[1] -> Argument[0]` |

This is content-**insensitive** — an over-approximation: storing a tainted value taints the whole container, and reading any value back is tainted (e.g. a tainted map key makes value reads look tainted). It is **sound** — it can add false positives but never loses a flow — *because every store and read collapses uniformly*, so the two halves still reconnect at container granularity. The store/read connection is the same mechanism the engine already uses for `StringBuilder.append` (`Argument[0] -> Argument[this]`).

## Summary

- `ExternalFlowModels.Optimizer.optimize` now parses each endpoint via `AccessPath` (collapsing content) instead of `computeArgumentRange` (which dropped content rows). `AccessPath` is a strict superset for non-content paths, so plain models are unaffected.
- Callback endpoints (`Argument[i].Parameter[j]` / `.ReturnValue`) are skipped here — they remain owned by `buildCallbackModels` — as are the few unparseable `With/WithoutElement` typestate rows.
- Degenerate collapsed self-flows are skipped (e.g. `Argument[0].MapKey -> Argument[0].MapValue` → `0 -> 0`, and receiver→receiver).
- Documented the content/higher-order interpretation and known limitations in the data-flow README.

## Known limitation / follow-up

A **pre-existing** matcher gap (`Internal.typePattern` has no erasure for type-variable parameters) keeps a signed generic model such as `Map.put` (spelled `(Object,Object)` for the declared `put(K,V)`) from matching generic call sites — raw-type calls match, generic ones don't. So container **writes** through such methods (notably `Map.put`) are not yet tracked, though the reads are. A small follow-up to erase type variables in the matcher will unlock these. Full content/field-sensitivity (recovering the precision lost by collapsing) is a separate, larger follow-up.

## Test plan

- [x] New `ContentFlowTest`: collection add+get, `Optional` of+get, and map read — all now propagate taint.
- [x] Full `org.openrewrite.analysis.dataflow.*` suite green; **full module test suite green** — collapse activates ~7,900 previously-dropped models with no regressions.
- [x] `DataFlowMatchingBenchmark` (`-f 2 -wi 5 -i 5 -prof gc`): allocation 13.1 -> 16.8 MB/op (the collection/stream-dense benchmark genuinely finds more flows now); no throughput regression. (The separate lazy-message allocation fix more than offsets this.)