### PR TITLE
Match erased `Object` signatures against any reference type

### DIFF
--- a/src/main/java/org/openrewrite/analysis/dataflow/internal/csv/GenericExternalModel.java
+++ b/src/main/java/org/openrewrite/analysis/dataflow/internal/csv/GenericExternalModel.java
@@ -227,6 +227,16 @@ class Internal {
     }
 
     static boolean matches(JavaType parameter, String parameterSignature) {
+        // CodeQL signatures use erased types, so a type-variable position (e.g. the `K`/`V` of
+        // `Map.put(K, V)`) is written as `Object`. At a call site the type argument is substituted in
+        // (`Map<String, String>.put` has parameter types `String, String`) or the parameter is itself
+        // a type variable, neither of which equals `Object` by name. Treat an `Object` signature as
+        // matching any reference type so these models match; primitives still require an exact match.
+        if (("Object".equals(parameterSignature) || "java.lang.Object".equals(parameterSignature)) &&
+            !(parameter instanceof JavaType.Primitive)) {
+            return true;
+        }
+
         String parameterString = typePattern(parameter);
 
         if (parameterString == null) {

--- a/src/test/java/org/openrewrite/analysis/dataflow/ExternalModelMethodMatcherTest.java
+++ b/src/test/java/org/openrewrite/analysis/dataflow/ExternalModelMethodMatcherTest.java
@@ -445,4 +445,70 @@ class ExternalModelMethodMatcherTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void methodMatcherOnErasedObjectSignatureTwoParams() {
+        // CodeQL writes erased types, so `Map.put(K, V)` is spelled `(Object,Object)`. At the call site
+        // the type arguments are substituted in, so `Map<String, String>.put` has parameter types
+        // `String, String` -- which an `Object` signature must still match.
+        rewriteRun(
+          spec -> spec
+            .recipe(toRecipe(fromModel(
+              "java.util",
+              "Map",
+              true,
+              "put",
+              "(Object,Object)"))),
+          java(
+            """
+              import java.util.Map;
+              class Test {
+                  void test(Map<String, String> map) {
+                      map.put("k", "v");
+                  }
+              }
+              """,
+            """
+              /*~~>*/import java.util.Map;
+              class Test {
+                  void test(Map<String, String> map) {
+                      map.put("k", "v");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodMatcherOnErasedObjectSignatureOneParam() {
+        // `List.add(E)` is spelled `(Object)`; `List<String>.add` has parameter type `String`.
+        rewriteRun(
+          spec -> spec
+            .recipe(toRecipe(fromModel(
+              "java.util",
+              "List",
+              true,
+              "add",
+              "(Object)"))),
+          java(
+            """
+              import java.util.List;
+              class Test {
+                  void test(List<String> list) {
+                      list.add("x");
+                  }
+              }
+              """,
+            """
+              /*~~>*/import java.util.List;
+              class Test {
+                  void test(List<String> list) {
+                      list.add("x");
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Motivation

CodeQL writes model signatures with **erased** parameter types. A type-variable position is therefore spelled `Object` — `Map.put(K, V)` is `(Object,Object)`, `Collection.add(E)` (when given a signature) is `(Object)`, and so on.

At a call site, though, the type arguments are **substituted in**: `Map<String, String>.put` has parameter types `String, String`. The matcher (`Internal.matches`) compared the call's parameter type against the signature **by name**, so `String` ≠ `Object` and the model did not match. Only raw-type calls (`Map map`) or coincidentally `Object`-typed ones (`Map<Object, Object>`) matched — verified in isolation: `Map<Object,Object>.put` matches `(Object,Object)`, `Map<String,String>.put` does not.

- The effect: signed generic models — most importantly container **writes** like `Map.put` — never matched real call sites. This was latent until [#106](https://github.com/openrewrite/rewrite-analysis/pull/106) (content collapse) started activating these models; on its own, `map.put(taint)` still wouldn't taint the map because `Map.put` didn't match.

## Fix

Treat an `Object` signature position as matching **any reference-typed argument** (primitives still require an exact match). This is the erased-top-type semantics CodeQL intends — `Object` at a parameter position is the erasure of an unbounded type variable (or a genuine `Object` parameter, which still matches) — and it also covers a parameter that is itself a type variable. Concrete signatures (`String`, `int`, `Object[]`, ...) are unaffected.

## Summary

- `GenericExternalModel.Internal.matches`: an `Object` / `java.lang.Object` signature matches any non-primitive parameter type.

## Test plan

- [x] New `ExternalModelMethodMatcherTest` cases: a `(Object,Object)` model matches `Map<String,String>.put`, and a `(Object)` model matches `List<String>.add` — both rejected before this change.
- [x] **Full module test suite green** — loosening `Object` matching activates more signed models with no regressions.
- [x] End-to-end (verified locally with #106 merged in): `map.put("k", source()); String v = map.get("k"); sink(v);` now taints `v`. This PR and #106 compose to deliver container-write flows; neither alone is sufficient for `Map.put`.