### PR TITLE
Fix switch fallthrough: wire caseFlow to post-switch continuation

### DIFF
--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
@@ -57,7 +57,9 @@ public final class ControlFlow {
         }
         return start.computeMessageIfAbsent(CONTROL_FLOW_MESSAGE_KEY, __ -> {
             ControlFlowSimpleSummary summary = findControlFlowInternal(start, ControlFlowNode.GraphType.METHOD_BODY_OR_STATIC_INITIALIZER_OR_INSTANCE_INITIALIZER);
-            return Option.fromNull(ControlFlowSummary.forGraph(summary.start, summary.end));
+            ControlFlowSummary cfSummary = ControlFlowSummary.forGraph(summary.start, summary.end);
+            cfSummary.validate();
+            return Option.fromNull(cfSummary);
         });
     }
 
@@ -351,12 +353,43 @@ public final class ControlFlow {
         public J.Switch visitSwitch(J.Switch _switch, P p) {
             addCursorToBasicBlock();
             visit(_switch.getSelector(), p);
+            // The switch analysis requires a doubly-nested anonymous-class structure.
+            //
+            // OUTER anonymous class (this 'analysis' object):
+            //   - Holds 'caseFlow': the set of BasicBlocks that fall off the end of a case
+            //     without a break/return. This set is shared across all case analyses via closure.
+            //   - Overrides visitBlock: called exactly ONCE for the J.Block that contains all
+            //     cases (_switch.getCases()). After super.visitBlock() returns (all cases have
+            //     been visited), any remaining caseFlow entries are wired to the post-switch
+            //     continuation by merging them into breakFlow.
+            //   - Overrides createAnalysisForRecursion: the base-class visitStatementList()
+            //     calls visitRecursive() -> createAnalysisForRecursion() for EACH case statement.
+            //     If we did NOT override createAnalysisForRecursion, each case would be visited
+            //     by a plain ControlFlowAnalysis whose visitCase() throws for non-default cases.
+            //
+            // INNER anonymous class (returned by createAnalysisForRecursion):
+            //   - Has its own current/breakFlow/exitFlow (isolated per case, as visitRecursive
+            //     requires), but shares caseFlow with the OUTER class via closure.
+            //   - Overrides visitCase: the only place where switch-specific CFG wiring can
+            //     happen. It CANNOT live in the OUTER class because the base visitStatementList
+            //     always routes each case through createAnalysisForRecursion — it never
+            //     dispatches directly back to the OUTER visitor's visitCase.
             ControlFlowAnalysis<P> analysis = new ControlFlowAnalysis<P>(current, graphType) {
 
                 /**
                  * Flows that exit a {@link J.Case} and don't complete with a {@link J.Break}.
                  */
                 private final Set<ControlFlowNode> caseFlow = new HashSet<>();
+
+                @Override
+                public J.Block visitBlock(J.Block block, P p) {
+                    J.Block result = super.visitBlock(block, p);
+                    // After all cases are visited, any remaining caseFlow entries are BasicBlocks
+                    // from the last case that fell off the end without a break/return. They must
+                    // flow to the post-switch continuation, identical to explicit break nodes.
+                    breakFlow.addAll(caseFlow);
+                    return result;
+                }
 
                 @Override
                 @SelfLoathing(name = "Jonathan Leitschuh")
@@ -369,6 +402,9 @@ public final class ControlFlow {
                                 // The default case is not a conditional node, there can be no `false` on a `default` case.
                                 // It's just like an `else` case.
                                 current = Stream.concat(current.stream(), caseFlow.stream()).collect(toSet());
+                                // caseFlow nodes are now merged into current and will be wired by addCursorToBasicBlock()
+                                // below. Clear caseFlow so the visitBlock override doesn't re-add them to breakFlow.
+                                caseFlow.clear();
                                 addCursorToBasicBlock();
                                 return super.visitCase(_case, p);
                             }

--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowIllegalStateException.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowIllegalStateException.java
@@ -18,6 +18,7 @@ package org.openrewrite.analysis.controlflow;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 
 import java.util.LinkedHashMap;
@@ -45,6 +46,7 @@ final class ControlFlowIllegalStateException extends IllegalStateException {
         Map<String, ControlFlowNode> nodes;
         Set<ControlFlowNode> predecessors;
         Cursor cursor;
+        @Nullable String additionalContext;
 
         @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
         static final class MessageBuilder {
@@ -53,6 +55,7 @@ final class ControlFlowIllegalStateException extends IllegalStateException {
             private final Map<String, ControlFlowNode> nodes = new LinkedHashMap<>();
             private final Set<ControlFlowNode> predecessors = new LinkedHashSet<>();
             private Cursor cursor;
+            @Nullable private String additionalContext;
 
             MessageBuilder thisNode(ControlFlowNode node) {
                 return addNode("This", node);
@@ -82,8 +85,13 @@ final class ControlFlowIllegalStateException extends IllegalStateException {
                 return this;
             }
 
+            MessageBuilder additionalContext(String context) {
+                this.additionalContext = context;
+                return this;
+            }
+
             Message build() {
-                return new Message(this.message, this.nodes, this.predecessors, cursor);
+                return new Message(this.message, this.nodes, this.predecessors, cursor, additionalContext);
             }
         }
 
@@ -98,6 +106,9 @@ final class ControlFlowIllegalStateException extends IllegalStateException {
             );
             if (!predecessors.isEmpty()) {
                 sb.append("\n\tPredecessors: ").append(predecessors.stream().map(ControlFlowNode::toDescriptiveString).reduce("\n\t\t", (a, b) -> a + "\n\t\t" + b));
+            }
+            if (additionalContext != null) {
+                sb.append("\n").append(additionalContext);
             }
             return sb.toString();
         }

--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowNode.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowNode.java
@@ -50,6 +50,16 @@ public abstract class ControlFlowNode {
 
     abstract Set<ControlFlowNode> getSuccessors();
 
+    /**
+     * Returns the successors of this node for the purpose of graph traversal, without enforcing invariants.
+     * For correctly built graphs this will never return an empty set for a {@link BasicBlock}.
+     * Returning an empty set for a {@link BasicBlock} indicates a broken graph and is only intended
+     * to assist with debugging (e.g., DOT visualization of the malformed graph).
+     */
+    Set<ControlFlowNode> getSuccessorsForTraversal() {
+        return getSuccessors();
+    }
+
     protected abstract void _addSuccessorInternal(ControlFlowNode successor);
 
     Set<ControlFlowNode> getPredecessors() {
@@ -382,9 +392,24 @@ public abstract class ControlFlowNode {
         @Override
         Set<ControlFlowNode> getSuccessors() {
             if (successor == null) {
-                return  emptySet(); // e.g. a switch statement without a break / return
+                throw new ControlFlowIllegalStateException(exceptionMessageBuilder("Basic block has no successor").thisNode(this));
             }
             return singleton(successor);
+        }
+
+        /**
+         * Returns true if this basic block has a successor.
+         * For correctly built graphs this will always return true.
+         * Returning false indicates a broken graph (e.g., a switch case body not properly wired
+         * to the post-switch continuation).
+         */
+        boolean hasSuccessor() {
+            return successor != null;
+        }
+
+        @Override
+        Set<ControlFlowNode> getSuccessorsForTraversal() {
+            return successor != null ? singleton(successor) : emptySet();
         }
 
         @Override

--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowSummary.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowSummary.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.tree.Expression;
 import java.util.*;
 import java.util.function.Function;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 /**
@@ -42,7 +43,9 @@ public final class ControlFlowSummary {
     private static Set<ControlFlowNode> getAllControlFlowNodes(ControlFlowNode.Start start, ControlFlowNode.End end) {
         // LinkedHashSet to preserve insertion order of nodes
         Set<ControlFlowNode> all = new LinkedHashSet<>();
-        recurseGetAllControlFlowNodes(start, all, ControlFlowNode::getSuccessors);
+        // Use getSuccessorsForTraversal() so that broken graphs (BasicBlocks with no successor) can
+        // still be fully traversed for visualization and validation — without throwing prematurely.
+        recurseGetAllControlFlowNodes(start, all, ControlFlowNode::getSuccessorsForTraversal);
         // Sometimes the end may not be reachable because of an infinite loop.
         // In this case, we need to add the end node and look backwards as well to capture 'all' nodes.
         recurseGetAllControlFlowNodes(end, all, ControlFlowNode::getPredecessors);
@@ -124,5 +127,31 @@ public final class ControlFlowSummary {
 
     int getExitCount() {
         return end.getPredecessors().size();
+    }
+
+    /**
+     * Validates that the control flow graph satisfies all structural invariants.
+     * On violation, generates a DOT representation of the (possibly malformed) graph and throws
+     * a {@link ControlFlowIllegalStateException} with both the violation details and the DOT embedded,
+     * so the graph can be visualized even when broken.
+     */
+    void validate() {
+        List<ControlFlowNode.BasicBlock> blocksWithNoSuccessor = getAllNodes()
+                .stream()
+                .filter(ControlFlowNode.BasicBlock.class::isInstance)
+                .map(ControlFlowNode.BasicBlock.class::cast)
+                .filter(bb -> !bb.hasSuccessor())
+                .collect(toList());
+        if (!blocksWithNoSuccessor.isEmpty()) {
+            String dot = ControlFlowDotFileGenerator.create().visualizeAsDotfile("broken_graph", false, this);
+            ControlFlowIllegalStateException.Message.MessageBuilder builder =
+                    ControlFlowIllegalStateException.exceptionMessageBuilder(
+                            "Control flow graph has " + blocksWithNoSuccessor.size() + " basic block(s) with no successor"
+                    ).additionalContext("DOT representation of the malformed graph:\n" + dot);
+            for (int i = 0; i < blocksWithNoSuccessor.size(); i++) {
+                builder.addNode("BasicBlock without successor " + (i + 1), blocksWithNoSuccessor.get(i));
+            }
+            throw new ControlFlowIllegalStateException(builder);
+        }
     }
 }

--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowSummaryDotVisualizer.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlowSummaryDotVisualizer.java
@@ -94,7 +94,7 @@ final class ControlFlowSummaryDotVisualizer implements ControlFlowDotFileGenerat
                     sb.append(" [label=\"Unreachable\", color=\"grey\" fontcolor=\"grey\" style=dashed];");
                 }
             } else {
-                for (ControlFlowNode successor : node.getSuccessors()) {
+                for (ControlFlowNode successor : node.getSuccessorsForTraversal()) {
                     sb.append("\n    ").append(abstractToVisualNodeMapping.get(node))
                             .append(" -> ").append(abstractToVisualNodeMapping.get(successor)).append(";");
                 }

--- a/src/test/java/org/openrewrite/analysis/controlflow/ControlFlowTest.java
+++ b/src/test/java/org/openrewrite/analysis/controlflow/ControlFlowTest.java
@@ -2753,6 +2753,7 @@ class ControlFlowTest implements RewriteTest {
     }
 
     @Test
+    @SuppressWarnings("EnhancedSwitchMigration")
     void switchCaseNoDefault() {
         rewriteRun(
           //language=java
@@ -2833,6 +2834,133 @@ class ControlFlowTest implements RewriteTest {
                             /*~~(4L)~~>*/System.out.println("B");
                     }
                     /*~~(5L)~~>*/System.out.println("done");
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    @SuppressWarnings("EnhancedSwitchMigration")
+    void switchCaseSingleCaseNoBreak() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            class Test {
+                enum E { A, B }
+
+                void test(E x) {
+                    switch (x) {
+                        case A:
+                            System.out.println("A");
+                    }
+                    System.out.println("done");
+                }
+            }
+            """,
+            """
+            class Test {
+                enum E { A, B }
+
+                void test(E x) /*~~(BB: 3 CN: 1 EX: 1 | 1L)~~>*/{
+                    switch (x) {
+                        /*~~(1C)~~>*/case A:
+                            /*~~(2L)~~>*/System.out.println("A");
+                    }
+                    /*~~(3L)~~>*/System.out.println("done");
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void switchCaseEnhancedBlockBody() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            class Test {
+                void test(int x) {
+                    switch (x) {
+                        case 1 -> {
+                            System.out.println("one");
+                        }
+                        case 2 -> {
+                            System.out.println("two");
+                        }
+                        default -> {
+                            System.out.println("other");
+                        }
+                    }
+                }
+            }
+            """,
+            """
+            class Test {
+                void test(int x) /*~~(BB: 5 CN: 2 EX: 3 | 1L)~~>*/{
+                    switch (x) {
+                        /*~~(1C)~~>*/case 1 -> /*~~(2L)~~>*/{
+                            System.out.println("one");
+                        }
+                        /*~~(3L | 2C)~~>*/case 2 -> /*~~(4L)~~>*/{
+                            System.out.println("two");
+                        }
+                        /*~~(5L)~~>*/default -> {
+                            System.out.println("other");
+                        }
+                    }
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    @SuppressWarnings("EnhancedSwitchMigration")
+    void switchCaseMixedFallthrough() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            class Test {
+                enum E { A, B, C }
+
+                void test(E x) {
+                    switch (x) {
+                        case A:
+                            System.out.println("A");
+                            break;
+                        case B:
+                            System.out.println("B");
+                        case C:
+                            System.out.println("C");
+                            break;
+                    }
+                    System.out.println("done");
+                }
+            }
+            """,
+            """
+            class Test {
+                enum E { A, B, C }
+
+                void test(E x) /*~~(BB: 7 CN: 3 EX: 1 | 1L)~~>*/{
+                    switch (x) {
+                        /*~~(1C)~~>*/case A:
+                            /*~~(2L)~~>*/System.out.println("A");
+                            break;
+                        /*~~(3L | 2C)~~>*/case B:
+                            /*~~(4L)~~>*/System.out.println("B");
+                        /*~~(5L | 3C)~~>*/case C:
+                            /*~~(6L)~~>*/System.out.println("C");
+                            break;
+                    }
+                    /*~~(7L)~~>*/System.out.println("done");
                 }
             }
             """


### PR DESCRIPTION
## Summary

- Fixes #97. PR #79 introduced a bug by silencing a `ControlFlowIllegalStateException` in `BasicBlock.getSuccessors()` instead of fixing the underlying graph construction error. This PR fixes the root cause and restores the original invariant guard.

**Root cause:** `visitSwitch` in `ControlFlow.java` accumulates fallthrough `BasicBlock`s (from case bodies with no `break`) in a `caseFlow` set, but never wires them to the post-switch continuation. The fix adds a `visitBlock` override to the outer switch analysis that, after all cases are processed, merges remaining `caseFlow` entries into `breakFlow` so they get wired identically to explicit `break` nodes. The `default` case handling also receives a `caseFlow.clear()` to prevent double-wiring nodes it already consumed.

**Catch-22 solution:** The original exception in `BasicBlock.getSuccessors()` prevented DOT visualization of broken graphs (because the traversal itself threw). This is resolved by:
- A new `getSuccessorsForTraversal()` method used by graph traversal and the DOT visualizer — returns empty safely without throwing
- `BasicBlock.getSuccessors()` retains the invariant guard (restored throw) for production data-flow analysis
- A new `ControlFlowSummary.validate()` method checks invariants post-build and, on violation, generates the DOT representation of the malformed graph and embeds it in the exception — giving both a call stack and a visual of the problem

**Documentation:** Detailed comments explain why `visitSwitch` requires a doubly-nested anonymous-class structure (`visitCase` must live in the inner class returned by `createAnalysisForRecursion` because `visitStatementList` routes each case through that factory method — there is no dispatch path that would invoke `visitCase` on the outer class directly).

## Test plan

- [x] `switchCaseNoBreakOrReturn` — existing test now exercises the correct graph (was passing with a silently broken graph before)
- [x] `switchCaseSingleCaseNoBreak` — new: minimal single-case fallthrough (the original PR #79 bug report)
- [x] `switchCaseMixedFallthrough` — new: case B falls through to case C which has a break
- [x] `switchCaseEnhancedBlockBody` — new: enhanced switch (`->`) with block bodies (previously untested code path)
- [x] `switchCaseFallthroughToDefault`, `switchCase`, `switchCaseTwoMatches`, `switchCaseNoDefault` — all existing switch tests pass (regression check)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)