### PR TITLE
Support switch expressions in control flow analysis

### DIFF
--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
@@ -351,8 +351,26 @@ public final class ControlFlow {
         @Override
         @SelfLoathing(name = "Jonathan Leitschuh")
         public J.Switch visitSwitch(J.Switch _switch, P p) {
+            visitSwitchLike(_switch.getSelector(), _switch.getCases(), p);
+            return _switch;
+        }
+
+        @Override
+        @SelfLoathing(name = "Jonathan Leitschuh")
+        public J.SwitchExpression visitSwitchExpression(J.SwitchExpression _switch, P p) {
+            // A switch expression has the same case/label structure as a switch
+            // statement; the only difference is that its cases produce a value via
+            // `yield` (or an arrow body) rather than falling through / breaking.
+            // Control-flow-wise a `yield` behaves like a `break` (see visitYield),
+            // so the exact same analysis applies.
+            visitSwitchLike(_switch.getSelector(), _switch.getCases(), p);
+            return _switch;
+        }
+
+        @SelfLoathing(name = "Jonathan Leitschuh")
+        private void visitSwitchLike(J selector, J.Block cases, P p) {
             addCursorToBasicBlock();
-            visit(_switch.getSelector(), p);
+            visit(selector, p);
             // The switch analysis requires a doubly-nested anonymous-class structure.
             //
             // OUTER anonymous class (this 'analysis' object):
@@ -423,7 +441,12 @@ public final class ControlFlow {
                                 }
                             } else if (_case.getType() == J.Case.Type.Rule) {
                                 visit(_case.getBody(), p);
-                                breakFlow.add(currentAsBasicBlock());
+                                if (!current.isEmpty()) {
+                                    // An arrow body that ends in `yield`/`return`/`throw`
+                                    // (e.g. `case X -> { yield 1; }`) has already emptied
+                                    // current and recorded its own exit flow.
+                                    breakFlow.add(currentAsBasicBlock());
+                                }
                                 current = emptySet();
                             }
                             caseFlow.addAll(current);
@@ -433,11 +456,10 @@ public final class ControlFlow {
                     };
                 }
             };
-            analysis.visit(_switch.getCases(), p, getCursor());
+            analysis.visit(cases, p, getCursor());
             transferContinueFlow(analysis);
             transferExit(analysis);
             current = Stream.concat(analysis.current.stream(), analysis.breakFlow.stream()).collect(toSet());
-            return _switch;
         }
 
         @Override
@@ -1002,6 +1024,18 @@ public final class ControlFlow {
             breakFlow.add(currentAsBasicBlock());
             current = emptySet();
             return breakStatement;
+        }
+
+        @Override
+        public J.Yield visitYield(J.Yield yield, P p) {
+            // `yield` exits the enclosing switch expression carrying a value.
+            // For control-flow purposes it behaves exactly like a `break`: the
+            // value expression is evaluated, then flow leaves the switch.
+            visit(yield.getValue(), p);
+            addCursorToBasicBlock();
+            breakFlow.add(currentAsBasicBlock());
+            current = emptySet();
+            return yield;
         }
 
         private static ControlFlowNode.BasicBlock addBasicBlock(Collection<ControlFlowNode> nodes) {

--- a/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
+++ b/src/main/java/org/openrewrite/analysis/controlflow/ControlFlow.java
@@ -356,7 +356,6 @@ public final class ControlFlow {
         }
 
         @Override
-        @SelfLoathing(name = "Jonathan Leitschuh")
         public J.SwitchExpression visitSwitchExpression(J.SwitchExpression _switch, P p) {
             // A switch expression has the same case/label structure as a switch
             // statement; the only difference is that its cases produce a value via
@@ -367,7 +366,6 @@ public final class ControlFlow {
             return _switch;
         }
 
-        @SelfLoathing(name = "Jonathan Leitschuh")
         private void visitSwitchLike(J selector, J.Block cases, P p) {
             addCursorToBasicBlock();
             visit(selector, p);

--- a/src/test/java/org/openrewrite/analysis/controlflow/ControlFlowTest.java
+++ b/src/test/java/org/openrewrite/analysis/controlflow/ControlFlowTest.java
@@ -2963,4 +2963,78 @@ class ControlFlowTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2735")
+    @Test
+    void switchExpressionWithYield() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            class Test {
+                String test(int x) {
+                    String result = switch (x) {
+                        case 1:
+                            yield "one";
+                        case 2:
+                            yield "two";
+                        default:
+                            yield "other";
+                    };
+                    return result;
+                }
+            }
+            """,
+            """
+            class Test {
+                String test(int x) /*~~(BB: 6 CN: 2 EX: 1 | 1L)~~>*/{
+                    String /*~~(2L)~~>*/result = switch (x) {
+                        /*~~(1C)~~>*/case 1:
+                            yield /*~~(3L)~~>*/"one";
+                        /*~~(4L | 2C)~~>*/case 2:
+                            yield /*~~(5L)~~>*/"two";
+                        /*~~(6L)~~>*/default:
+                            yield "other";
+                    };
+                    return result;
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2735")
+    @Test
+    void switchExpressionWithArrow() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            class Test {
+                String test(int x) {
+                    String result = switch (x) {
+                        case 1 -> "one";
+                        case 2 -> "two";
+                        default -> "other";
+                    };
+                    return result;
+                }
+            }
+            """,
+            """
+            class Test {
+                String test(int x) /*~~(BB: 6 CN: 2 EX: 1 | 1L)~~>*/{
+                    String /*~~(2L)~~>*/result = switch (x) {
+                        /*~~(1C)~~>*/case 1 -> /*~~(3L)~~>*/"one";
+                        /*~~(4L | 2C)~~>*/case 2 -> /*~~(5L)~~>*/"two";
+                        /*~~(6L)~~>*/default -> "other";
+                    };
+                    return result;
+                }
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed

`ControlFlowAnalysis` only handled switch *statements* (`J.Switch`). Switch *expressions* (`J.SwitchExpression`, e.g. cases using `yield` or arrow bodies) had no dedicated handling, so their case labels fell through to the base `visitCase`, which throws:

```
org.openrewrite.analysis.controlflow.ControlFlowIllegalStateException: Case statements should be visited by the switch statement
```

This change:
- Extracts the shared switch-handling logic into `visitSwitchLike(selector, cases, p)` and reuses it from both `visitSwitch` and a new `visitSwitchExpression`.
- Adds `visitYield`, which for control-flow purposes behaves exactly like `break` (evaluate the value, then leave the switch).
- Makes the arrow-case (`Case.Type.Rule`) branch defensive against bodies that end in `yield`/`return`/`throw` (which leave `current` empty).

## Why

Because the crash originates deep inside dataflow-backed recipes (e.g. any recipe using `ConstantFold`, such as `URLConstructorToURICreate`), it propagated out of whatever recipe happened to be running and the SaaS layer misattributed the stack trace to an unrelated recipe — leading to confusing reports and misdirected debugging.

- Reported in https://github.com/moderneinc/customer-requests/issues/2735.

## Tests

Added `switchExpressionWithYield` and `switchExpressionWithArrow` to `ControlFlowTest`, and confirmed the full `controlflow` and `dataflow` suites pass.